### PR TITLE
refactor: move screen components from App.tsx to src/ui/screens/

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useGameStore } from '@store/index';
-import { MainMenu, NewGame } from '@ui/screens';
-import { GameHeader, GameHUD, ActivityPanel, EventLog } from '@ui/components/game';
-import { loadEconomyData, loadCoreActivities, getEconomyConfig, type GameEvent } from '@engine/index';
+import { MainMenu, NewGame, GameScreen, GameOverScreen, PlaceholderScreen } from '@ui/screens';
+import { loadEconomyData, loadCoreActivities } from '@engine/index';
 
 type DataStatus = 'loading' | 'loaded' | 'error';
 
@@ -63,113 +62,6 @@ function App() {
   };
 
   return <div className="app">{renderScreen()}</div>;
-}
-
-function GameScreen({
-  gameState,
-}: {
-  gameState: NonNullable<ReturnType<typeof useGameStore.getState>['gameState']>;
-}) {
-  const resetGame = useGameStore((state) => state.resetGame);
-  const performActivity = useGameStore((state) => state.performActivity);
-  const pendingEvents = useGameStore((state) => state.pendingEvents);
-  const clearEvents = useGameStore((state) => state.clearEvents);
-
-  const [message, setMessage] = useState<string | null>(null);
-
-  const economyConfig = getEconomyConfig();
-  const foodCost = economyConfig.survival.dailyFoodCost;
-  const starvationDays = economyConfig.survival.daysWithoutFoodUntilDeath;
-
-  const handleActivity = (activityId: string, params: { hours?: number } = {}) => {
-    const result = performActivity(activityId, params);
-    if (result.narrative) {
-      setMessage(result.narrative);
-    } else if (result.error) {
-      setMessage(`Failed: ${result.error}`);
-    }
-  };
-
-  const canAffordFood = gameState.player.money >= foodCost;
-
-  return (
-    <div className="screen game-screen">
-      <GameHeader time={gameState.time} />
-
-      <GameHUD money={gameState.player.money} energy={gameState.player.energy} />
-
-      {/* Food warning */}
-      {gameState.player.daysWithoutFood > 0 && (
-        <div className="warning food-warning">
-          Days without food: {gameState.player.daysWithoutFood}/{starvationDays} - EAT OR DIE!
-        </div>
-      )}
-
-      <div className="player-info">
-        <h2>{gameState.player.name}</h2>
-        <div className="stats-display">
-          <div className="stat">CHA: {gameState.player.stats.charisma}</div>
-          <div className="stat">MEC: {gameState.player.stats.mechanical}</div>
-          <div className="stat">FIT: {gameState.player.stats.fitness}</div>
-          <div className="stat">KNO: {gameState.player.stats.knowledge}</div>
-          <div className="stat">DRV: {gameState.player.stats.driving}</div>
-        </div>
-      </div>
-
-      <ActivityPanel
-        foodCost={foodCost}
-        canAffordFood={canAffordFood}
-        onActivity={handleActivity}
-      />
-
-      {/* Message display */}
-      {message && (
-        <div className="message-display">
-          <p>{message}</p>
-          <button onClick={() => setMessage(null)}>OK</button>
-        </div>
-      )}
-
-      <EventLog events={pendingEvents} onDismiss={clearEvents} />
-
-      <button className="quit-button" onClick={resetGame}>
-        Quit to Menu
-      </button>
-    </div>
-  );
-}
-
-function GameOverScreen({ events }: { events: GameEvent[] }) {
-  const resetGame = useGameStore((state) => state.resetGame);
-  const clearEvents = useGameStore((state) => state.clearEvents);
-
-  const handleReturn = () => {
-    clearEvents();
-    resetGame();
-  };
-
-  // Find death reason from events
-  const deathEvent = events.find((e) => e.type === 'death');
-  const deathReason = deathEvent?.message ?? 'You died.';
-
-  return (
-    <div className="screen game-over-screen">
-      <h1>Game Over</h1>
-      <p className="death-reason">{deathReason}</p>
-      <button onClick={handleReturn}>Return to Menu</button>
-    </div>
-  );
-}
-
-function PlaceholderScreen({ title }: { title: string }) {
-  const resetGame = useGameStore((state) => state.resetGame);
-
-  return (
-    <div className="screen placeholder-screen">
-      <h1>{title}</h1>
-      <button onClick={resetGame}>Return to Menu</button>
-    </div>
-  );
 }
 
 export default App;

--- a/src/ui/screens/GameOverScreen.tsx
+++ b/src/ui/screens/GameOverScreen.tsx
@@ -1,0 +1,24 @@
+import { useGameStore } from '@store/index';
+import type { GameEvent } from '@engine/index';
+
+export function GameOverScreen({ events }: { events: GameEvent[] }) {
+  const resetGame = useGameStore((state) => state.resetGame);
+  const clearEvents = useGameStore((state) => state.clearEvents);
+
+  const handleReturn = () => {
+    clearEvents();
+    resetGame();
+  };
+
+  // Find death reason from events
+  const deathEvent = events.find((e) => e.type === 'death');
+  const deathReason = deathEvent?.message ?? 'You died.';
+
+  return (
+    <div className="screen game-over-screen">
+      <h1>Game Over</h1>
+      <p className="death-reason">{deathReason}</p>
+      <button onClick={handleReturn}>Return to Menu</button>
+    </div>
+  );
+}

--- a/src/ui/screens/GameScreen.tsx
+++ b/src/ui/screens/GameScreen.tsx
@@ -1,0 +1,78 @@
+import { useState } from 'react';
+import { useGameStore } from '@store/index';
+import { GameHeader, GameHUD, ActivityPanel, EventLog } from '@ui/components/game';
+import { getEconomyConfig } from '@engine/index';
+
+export function GameScreen({
+  gameState,
+}: {
+  gameState: NonNullable<ReturnType<typeof useGameStore.getState>['gameState']>;
+}) {
+  const resetGame = useGameStore((state) => state.resetGame);
+  const performActivity = useGameStore((state) => state.performActivity);
+  const pendingEvents = useGameStore((state) => state.pendingEvents);
+  const clearEvents = useGameStore((state) => state.clearEvents);
+
+  const [message, setMessage] = useState<string | null>(null);
+
+  const economyConfig = getEconomyConfig();
+  const foodCost = economyConfig.survival.dailyFoodCost;
+  const starvationDays = economyConfig.survival.daysWithoutFoodUntilDeath;
+
+  const handleActivity = (activityId: string, params: { hours?: number } = {}) => {
+    const result = performActivity(activityId, params);
+    if (result.narrative) {
+      setMessage(result.narrative);
+    } else if (result.error) {
+      setMessage(`Failed: ${result.error}`);
+    }
+  };
+
+  const canAffordFood = gameState.player.money >= foodCost;
+
+  return (
+    <div className="screen game-screen">
+      <GameHeader time={gameState.time} />
+
+      <GameHUD money={gameState.player.money} energy={gameState.player.energy} />
+
+      {/* Food warning */}
+      {gameState.player.daysWithoutFood > 0 && (
+        <div className="warning food-warning">
+          Days without food: {gameState.player.daysWithoutFood}/{starvationDays} - EAT OR DIE!
+        </div>
+      )}
+
+      <div className="player-info">
+        <h2>{gameState.player.name}</h2>
+        <div className="stats-display">
+          <div className="stat">CHA: {gameState.player.stats.charisma}</div>
+          <div className="stat">MEC: {gameState.player.stats.mechanical}</div>
+          <div className="stat">FIT: {gameState.player.stats.fitness}</div>
+          <div className="stat">KNO: {gameState.player.stats.knowledge}</div>
+          <div className="stat">DRV: {gameState.player.stats.driving}</div>
+        </div>
+      </div>
+
+      <ActivityPanel
+        foodCost={foodCost}
+        canAffordFood={canAffordFood}
+        onActivity={handleActivity}
+      />
+
+      {/* Message display */}
+      {message && (
+        <div className="message-display">
+          <p>{message}</p>
+          <button onClick={() => setMessage(null)}>OK</button>
+        </div>
+      )}
+
+      <EventLog events={pendingEvents} onDismiss={clearEvents} />
+
+      <button className="quit-button" onClick={resetGame}>
+        Quit to Menu
+      </button>
+    </div>
+  );
+}

--- a/src/ui/screens/PlaceholderScreen.tsx
+++ b/src/ui/screens/PlaceholderScreen.tsx
@@ -1,0 +1,12 @@
+import { useGameStore } from '@store/index';
+
+export function PlaceholderScreen({ title }: { title: string }) {
+  const resetGame = useGameStore((state) => state.resetGame);
+
+  return (
+    <div className="screen placeholder-screen">
+      <h1>{title}</h1>
+      <button onClick={resetGame}>Return to Menu</button>
+    </div>
+  );
+}

--- a/src/ui/screens/index.ts
+++ b/src/ui/screens/index.ts
@@ -1,2 +1,5 @@
 export { MainMenu } from './MainMenu';
 export { NewGame } from './NewGame';
+export { GameScreen } from './GameScreen';
+export { GameOverScreen } from './GameOverScreen';
+export { PlaceholderScreen } from './PlaceholderScreen';


### PR DESCRIPTION
## Summary
- Moved `GameScreen`, `GameOverScreen`, and `PlaceholderScreen` from `App.tsx` to `src/ui/screens/`
- `App.tsx` now focused on routing/orchestration only
- Added exports to `src/ui/screens/index.ts`

Closes #8

## Test plan
- [ ] Verify app loads without errors
- [ ] Navigate through all screens (main menu, new game, game, game over, victory)
- [ ] Confirm no TypeScript or lint errors