### PR TITLE
feat: add map painter utility

### DIFF
--- a/tools/map-painter.html
+++ b/tools/map-painter.html
@@ -301,8 +301,12 @@
         <input type="checkbox" id="highlightLocations" checked onchange="render()">
         Highlight Locations
       </label>
+      <label style="margin-left: 20px;">
+        Zoom: <input type="range" id="zoomSlider" min="8" max="48" value="24" onchange="updateZoom(this.value)" style="width: 100px; vertical-align: middle;">
+        <span id="zoomValue">24px</span>
+      </label>
       <span style="margin-left: auto; font-size: 12px; color: #888;">
-        Left-click: Paint | Right-click: Erase (grass) | Drag: Paint multiple
+        Left-click: Paint | Right-click: Erase (grass) | Drag: Bounding box
       </span>
     </div>
     <div class="canvas-container">
@@ -342,7 +346,7 @@
     const TILESET_WIDTH = 37;
     const TILESET_HEIGHT = 28;
     const TILE_WITH_SPACING = TILE_SIZE + TILE_SPACING;
-    const DISPLAY_TILE_SIZE = 24; // Size to display on canvas
+    let DISPLAY_TILE_SIZE = 24; // Size to display on canvas (adjustable via zoom)
 
     // Tileset image
     const tilesetImg = new Image();
@@ -749,6 +753,14 @@
     canvas.addEventListener('contextmenu', (e) => e.preventDefault());
 
     // Control functions
+    function updateZoom(value) {
+      DISPLAY_TILE_SIZE = parseInt(value);
+      document.getElementById('zoomValue').textContent = value + 'px';
+      canvas.width = gridWidth * DISPLAY_TILE_SIZE;
+      canvas.height = gridHeight * DISPLAY_TILE_SIZE;
+      render();
+    }
+
     function resizeGrid() {
       gridWidth = parseInt(document.getElementById('gridWidth').value) || 40;
       gridHeight = parseInt(document.getElementById('gridHeight').value) || 30;


### PR DESCRIPTION
## Summary
- Adds standalone HTML map painter utility in `tools/map-painter.html`
- Allows painting the game map using the actual tileset
- Features: tile palette, grid with toggleable cell labels, location assignment, export to JSON

## Test plan
- [ ] Open `tools/map-painter.html` in browser
- [ ] Verify tileset loads and tiles are selectable
- [ ] Test painting and erasing on grid
- [ ] Toggle labels and grid lines
- [ ] Test export functionality