### PR TITLE
fix: issues 21, 24 - food auto-deduct and STAT_ORDER extraction

### DIFF
--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -14,6 +14,10 @@ export const MAX_STAT_LEVEL = 20;
 export const HOURS_PER_DAY = 24;
 export const MAX_PLAYER_NAME_LENGTH = 20;
 
+// Stat order for consistent UI display
+import type { StatName } from './types';
+export const STAT_ORDER: StatName[] = ['charisma', 'mechanical', 'fitness', 'knowledge', 'driving'];
+
 // RNG
 export { RNG, createRNG, deriveRNG } from './utils/rng';
 

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -289,6 +289,7 @@ export interface StateDelta {
 
 export type GameEventType =
   | 'food_eaten'
+  | 'food_purchased'
   | 'new_day'
   | 'hunger_warning'
   | 'hunger_critical'

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -366,6 +366,7 @@ export const useGameStore = create<GameStore>()(
             ...newState,
             player: {
               ...newState.player,
+              money: newState.player.money + dayResult.moneyChange,
               daysWithoutFood: dayResult.daysWithoutFood,
             },
           };

--- a/src/ui/components/game/ActivityPanel.tsx
+++ b/src/ui/components/game/ActivityPanel.tsx
@@ -1,26 +1,16 @@
 import { useState } from 'react';
 
 interface ActivityPanelProps {
-  foodCost: number;
-  canAffordFood: boolean;
   onActivity: (activityId: string, params?: { hours?: number }) => void;
 }
 
-export function ActivityPanel({ foodCost, canAffordFood, onActivity }: ActivityPanelProps) {
+export function ActivityPanel({ onActivity }: ActivityPanelProps) {
   const [sleepHours, setSleepHours] = useState(8);
 
   return (
     <div className="activity-section">
       <h3>Actions</h3>
       <div className="activity-buttons">
-        <button
-          onClick={() => onActivity('eat')}
-          disabled={!canAffordFood}
-          className="activity-btn eat"
-        >
-          Eat (${foodCost})
-        </button>
-
         <div className="sleep-control">
           <label>
             Sleep: {sleepHours}h

--- a/src/ui/components/hud/Sidebar.tsx
+++ b/src/ui/components/hud/Sidebar.tsx
@@ -1,10 +1,8 @@
-import { PlayerStats, StatName } from '@engine/index';
+import { PlayerStats, STAT_ORDER } from '@engine/index';
 import { AnimatedClock } from './AnimatedClock';
 import { AnimatedMoney } from './AnimatedMoney';
 import { AnimatedEnergy } from './AnimatedEnergy';
 import './Sidebar.css';
-
-const STAT_ORDER: StatName[] = ['charisma', 'mechanical', 'fitness', 'knowledge', 'driving'];
 
 const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
 

--- a/src/ui/screens/NewGame.tsx
+++ b/src/ui/screens/NewGame.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react';
 import { useGameStore } from '@store/index';
-import { StatAllocation, StatName, STARTING_STAT_POINTS, MAX_PLAYER_NAME_LENGTH } from '@engine/index';
+import { StatAllocation, StatName, STARTING_STAT_POINTS, MAX_PLAYER_NAME_LENGTH, STAT_ORDER } from '@engine/index';
 
 interface ConfirmDialogProps {
   pointsRemaining: number;
@@ -55,8 +55,6 @@ const STAT_INFO: Record<StatName, { label: string; description: string }> = {
     description: 'Road trips, deliveries, fuel efficiency',
   },
 };
-
-const STAT_ORDER: StatName[] = ['charisma', 'mechanical', 'fitness', 'knowledge', 'driving'];
 
 export function NewGame() {
   const setScreen = useGameStore((state) => state.setScreen);


### PR DESCRIPTION
## Summary
- Fixed food system to auto-deduct $3/day at start of each day (issue #21)
- Removed manual "Eat" button from ActivityPanel since food is now automatic
- Extracted STAT_ORDER constant to shared location in engine/index.ts (issue #24)

## Changes
- `time.ts`: processNewDay() now checks if player can afford food, auto-deducts if so, otherwise increments hunger
- `store/index.ts`: Applies money change from new day processing
- `types.ts`: Added 'food_purchased' event type
- `ActivityPanel.tsx`: Removed Eat button and related props
- `engine/index.ts`: Added shared STAT_ORDER constant
- `NewGame.tsx`, `Sidebar.tsx`: Import STAT_ORDER from engine instead of defining locally

## Test plan
- [ ] Start new game, earn $3+, sleep/wait until next day - verify $3 deducted and no hunger warning
- [ ] Start new game with $0, sleep until next day - verify hunger counter increments
- [ ] Verify stats display correctly in both NewGame and Sidebar screens

Closes #21, closes #24