### PR TITLE
fix: always show hero.jpg first in main menu slideshow

### DIFF
--- a/src/ui/components/common/BackgroundSlideshow.tsx
+++ b/src/ui/components/common/BackgroundSlideshow.tsx
@@ -49,6 +49,7 @@ export function BackgroundSlideshow() {
   }, []);
 
   useEffect(() => {
+    indexRef.current = 0;
     nextSlide();
     const timer = setInterval(nextSlide, INTERVAL);
     return () => clearInterval(timer);


### PR DESCRIPTION
## Summary
- Resets `indexRef.current = 0` at the top of the slideshow effect, so the sequence always starts from `hero.jpg` regardless of how many times the effect runs

## Root cause
The `orderRef` already placed `hero.jpg` at index 0 correctly. The bug was that React StrictMode mounts/unmounts/remounts effects — on the remount, `indexRef` was already at 1 from the first run, causing a random image to show first instead of hero.

## What's unchanged
- Slideshow timing, transition style, and image set are untouched
- Remaining images still cycle in randomised order after hero.jpg