### PR TITLE
feat: Phase 3 car UI — car card, selector, browse modal

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -49,6 +49,7 @@ interface GameStore {
   currentTab: GameTab;
   selectedLocation: string | null;
   selectedActivity: ActivityDefinition | null;
+  selectedCarInstanceId: string | null;
   pendingEvents: GameEvent[];
   toasts: ToastMessage[];
   isExecutingActivity: boolean;
@@ -79,6 +80,7 @@ interface GameStore {
   setTab: (tab: GameTab) => void;
   setLocation: (locationId: string | null) => void;
   setSelectedActivity: (activity: ActivityDefinition | null) => void;
+  setSelectedCarInstanceId: (id: string | null) => void;
   setExecutingActivity: (isExecuting: boolean) => void;
 
   // Toast management
@@ -300,6 +302,7 @@ export const useGameStore = create<GameStore>()(
       currentTab: 'location',
       selectedLocation: null,
       selectedActivity: null,
+      selectedCarInstanceId: null,
       pendingEvents: [],
       toasts: [],
       isExecutingActivity: false,
@@ -367,6 +370,7 @@ export const useGameStore = create<GameStore>()(
           currentTab: 'location',
           selectedLocation: null,
           selectedActivity: null,
+          selectedCarInstanceId: null,
           error: null,
           pendingEvents: [],
           toasts: [],
@@ -716,6 +720,7 @@ export const useGameStore = create<GameStore>()(
       setTab: (tab) => set({ currentTab: tab }),
       setLocation: (locationId) => set({ selectedLocation: locationId }),
       setSelectedActivity: (activity) => set({ selectedActivity: activity }),
+      setSelectedCarInstanceId: (id) => set({ selectedCarInstanceId: id }),
       setExecutingActivity: (isExecuting) => set({ isExecutingActivity: isExecuting }),
 
       // Toast management

--- a/src/ui/components/location/ActivityCard.css
+++ b/src/ui/components/location/ActivityCard.css
@@ -108,11 +108,8 @@
 .card__cost-text--spend { color: var(--spend); }
 
 .card__locked {
-  margin-top: 12px;
-  padding: 8px;
-  font-size: 0.8rem;
-  color: var(--text-3);
-  background: rgba(0, 0, 0, 0.3);
-  border: var(--glass-3-border);
-  border-radius: var(--glass-3-radius);
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--spend);
+  margin-top: 8px;
 }

--- a/src/ui/components/location/BrowseResultsModal.css
+++ b/src/ui/components/location/BrowseResultsModal.css
@@ -1,0 +1,250 @@
+/* ==========================================================================
+   Browse Results Modal — Tier 1 Glass (Mockup 7)
+   ========================================================================== */
+
+.browse-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.browse-modal {
+  background: var(--glass-1-bg);
+  backdrop-filter: blur(var(--glass-1-blur));
+  -webkit-backdrop-filter: blur(var(--glass-1-blur));
+  border: var(--glass-1-border);
+  border-radius: var(--glass-1-radius);
+  box-shadow: var(--glass-1-shadow);
+  width: 560px;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  animation: browseModalIn 0.3s ease-out;
+}
+
+@keyframes browseModalIn {
+  from { opacity: 0; transform: scale(0.95) translateY(10px); }
+  to   { opacity: 1; transform: scale(1) translateY(0); }
+}
+
+/* ── Header ── */
+.browse-modal__header {
+  flex-shrink: 0;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  padding: 20px 28px 16px;
+  border-bottom: 1px solid var(--divider);
+  background: var(--glass-3-bg);
+}
+
+.browse-modal__title {
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--text-1);
+  text-shadow: var(--shadow-text);
+}
+
+.browse-modal__sub {
+  font-size: 0.8rem;
+  font-weight: 400;
+  color: var(--text-3);
+  text-shadow: var(--shadow-text);
+}
+
+/* ── Content ── */
+.browse-modal__content {
+  flex: 1;
+  padding: 20px 28px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.browse-modal__content::-webkit-scrollbar { width: 6px; }
+.browse-modal__content::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.15);
+  border-radius: 3px;
+}
+
+/* ── Footer ── */
+.browse-modal__footer {
+  flex-shrink: 0;
+  padding: 0 28px 24px;
+}
+
+.browse-modal__note {
+  font-size: 0.78rem;
+  font-weight: 400;
+  color: var(--text-3);
+  text-shadow: var(--shadow-text);
+  margin-bottom: 14px;
+  text-align: center;
+  font-style: italic;
+}
+
+.browse-modal__close {
+  display: block;
+  width: 100%;
+  padding: 12px 20px;
+  background: rgba(255, 255, 255, 0.10);
+  border: 1px solid rgba(255, 255, 255, 0.20);
+  border-radius: 8px;
+  color: var(--text-1);
+  font-family: var(--font-sans);
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  text-shadow: var(--shadow-text);
+  text-align: center;
+}
+
+.browse-modal__close:hover {
+  background: rgba(255, 255, 255, 0.16);
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
+.browse-modal__close:active {
+  transform: scale(0.98);
+  transition: all 0.1s ease;
+}
+
+/* ==========================================================================
+   Listing Card — Tier 2 Glass
+   ========================================================================== */
+
+.listing-card {
+  background: var(--glass-2-bg);
+  border: var(--glass-2-border);
+  border-radius: var(--glass-2-radius);
+  box-shadow: var(--glass-2-shadow);
+  display: flex;
+  overflow: hidden;
+  min-height: 90px;
+}
+
+.listing-card__image {
+  width: 120px;
+  min-width: 120px;
+  flex-shrink: 0;
+  background: rgba(255, 255, 255, 0.03);
+  position: relative;
+}
+
+.listing-card__image-bg {
+  position: absolute;
+  inset: 0;
+  background-size: cover;
+  background-position: center;
+}
+
+.listing-card__image-fade {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to right, transparent 55%, rgba(0, 0, 0, 0.4) 100%);
+}
+
+.listing-card__image-placeholder {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.68rem;
+  color: var(--text-3);
+  font-style: italic;
+  text-align: center;
+  padding: 8px;
+}
+
+.listing-card__info {
+  flex: 1;
+  padding: 12px 16px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  min-width: 0;
+}
+
+.listing-card__name {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-1);
+  text-shadow: var(--shadow-text);
+  margin-bottom: 6px;
+}
+
+/* ── Condition badges ── */
+.listing-card__badges {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.listing-badge {
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 2px 7px;
+  border-radius: 4px;
+}
+
+.listing-badge--good {
+  background: rgba(74, 222, 128, 0.12);
+  border: 1px solid rgba(74, 222, 128, 0.30);
+  color: var(--earn);
+}
+
+.listing-badge--fair {
+  background: rgba(251, 191, 36, 0.12);
+  border: 1px solid rgba(251, 191, 36, 0.30);
+  color: var(--energy-color);
+}
+
+.listing-badge--poor {
+  background: rgba(248, 113, 113, 0.12);
+  border: 1px solid rgba(248, 113, 113, 0.30);
+  color: var(--spend);
+}
+
+/* ── Footer: expires + price ── */
+.listing-card__footer {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  margin-top: 8px;
+}
+
+.listing-card__expires {
+  font-size: 0.72rem;
+  font-weight: 400;
+  color: var(--text-3);
+  text-shadow: var(--shadow-text);
+}
+
+.listing-card__price-wrap {
+  text-align: right;
+}
+
+.listing-card__price-label {
+  font-size: 0.65rem;
+  font-weight: 400;
+  color: var(--text-3);
+  text-shadow: var(--shadow-text);
+  display: block;
+}
+
+.listing-card__price {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--text-1);
+  text-shadow: var(--shadow-text);
+}

--- a/src/ui/components/location/BrowseResultsModal.tsx
+++ b/src/ui/components/location/BrowseResultsModal.tsx
@@ -1,0 +1,101 @@
+import type { CarListing, ConditionRating } from '@engine/types';
+import { getCarDefinition, getConditionRating } from '@engine/index';
+import './BrowseResultsModal.css';
+
+interface BrowseResultsModalProps {
+  listings: CarListing[];
+  currentDay: number;
+  onClose: () => void;
+}
+
+const RATING_LABELS: Record<ConditionRating, string> = {
+  excellent: 'Excellent',
+  good: 'Good',
+  fair: 'Fair',
+  poor: 'Poor',
+  scrap: 'Broken',
+};
+
+function badgeClass(rating: ConditionRating): string {
+  if (rating === 'excellent' || rating === 'good') return 'good';
+  if (rating === 'fair') return 'fair';
+  return 'poor';
+}
+
+export function BrowseResultsModal({ listings, currentDay, onClose }: BrowseResultsModalProps) {
+  return (
+    <div className="browse-backdrop" onClick={onClose}>
+      <div className="browse-modal" onClick={(e) => e.stopPropagation()}>
+        {/* Header */}
+        <div className="browse-modal__header">
+          <span className="browse-modal__title">Junkers at the Scrapyard</span>
+          <span className="browse-modal__sub">Day {currentDay}</span>
+        </div>
+
+        {/* Content */}
+        <div className="browse-modal__content">
+          {listings.map((listing) => {
+            const carDef = getCarDefinition(listing.carId);
+            if (!carDef) return null;
+            const name = `${carDef.year} ${carDef.make} ${carDef.model}`;
+            const hasImage = carDef.imageUrl !== '';
+            const engineRating = getConditionRating(listing.condition.engine);
+            const bodyRating = getConditionRating(listing.condition.body);
+
+            return (
+              <div key={listing.id} className="listing-card">
+                {/* Image */}
+                <div className="listing-card__image">
+                  {hasImage ? (
+                    <>
+                      <div
+                        className="listing-card__image-bg"
+                        style={{ backgroundImage: `url('${carDef.imageUrl}')` }}
+                      />
+                      <div className="listing-card__image-fade" />
+                    </>
+                  ) : (
+                    <>
+                      <div className="listing-card__image-fade" />
+                      <div className="listing-card__image-placeholder">No image</div>
+                    </>
+                  )}
+                </div>
+
+                {/* Info */}
+                <div className="listing-card__info">
+                  <div className="listing-card__name">{name}</div>
+                  <div className="listing-card__badges">
+                    <span className={`listing-badge listing-badge--${badgeClass(engineRating)}`}>
+                      Engine {'\u00B7'} {RATING_LABELS[engineRating]}
+                    </span>
+                    <span className={`listing-badge listing-badge--${badgeClass(bodyRating)}`}>
+                      Body {'\u00B7'} {RATING_LABELS[bodyRating]}
+                    </span>
+                  </div>
+                  <div className="listing-card__footer">
+                    <span className="listing-card__expires">
+                      {listing.expiresDay <= currentDay + 1 ? 'Expires tomorrow' : `Expires day ${listing.expiresDay}`}
+                    </span>
+                    <div className="listing-card__price-wrap">
+                      <span className="listing-card__price-label">Asking</span>
+                      <span className="listing-card__price">${listing.askingPrice}</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Footer */}
+        <div className="browse-modal__footer">
+          <div className="browse-modal__note">
+            These listings are held until tomorrow. Come back with cash to negotiate.
+          </div>
+          <button className="browse-modal__close" onClick={onClose}>Close</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/location/CarCard.css
+++ b/src/ui/components/location/CarCard.css
@@ -1,0 +1,190 @@
+/* ==========================================================================
+   Car Card — Tier 2 Glass (Mockup 7)
+   ========================================================================== */
+
+.car-card {
+  background: var(--glass-2-bg);
+  border: var(--glass-2-border);
+  border-radius: var(--glass-2-radius);
+  box-shadow: var(--glass-2-shadow);
+  display: flex;
+  overflow: hidden;
+  min-height: 150px;
+}
+
+.car-card__image {
+  width: 190px;
+  min-width: 190px;
+  flex-shrink: 0;
+  background: rgba(255, 255, 255, 0.03);
+  position: relative;
+}
+
+.car-card__image-bg {
+  position: absolute;
+  inset: 0;
+  background-size: cover;
+  background-position: center;
+}
+
+.car-card__image-fade {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to right, transparent 55%, rgba(0, 0, 0, 0.5) 100%);
+}
+
+.car-card__image-placeholder {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.72rem;
+  font-weight: 400;
+  color: var(--text-3);
+  font-style: italic;
+  text-align: center;
+  padding: 16px;
+  text-shadow: var(--shadow-text);
+}
+
+.car-card__info {
+  flex: 1;
+  padding: 14px 20px;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.car-card__name {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text-1);
+  text-shadow: var(--shadow-text);
+  margin-bottom: 10px;
+  line-height: 1.2;
+}
+
+.car-card__bio {
+  font-size: 0.78rem;
+  font-weight: 400;
+  color: var(--text-3);
+  line-height: 1.4;
+  font-style: italic;
+  text-shadow: var(--shadow-text);
+  margin-bottom: 8px;
+  max-width: 560px;
+}
+
+/* ── Condition bars ── */
+.car-stats {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  margin-bottom: 10px;
+  max-width: 480px;
+}
+
+.cond-row {
+  display: flex;
+  align-items: center;
+}
+
+.cond-row__label {
+  font-size: 0.65rem;
+  font-weight: 600;
+  color: var(--text-3);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  width: 48px;
+  flex-shrink: 0;
+}
+
+.cond-row__track {
+  flex: 1;
+  height: 5px;
+  background: rgba(255, 255, 255, 0.10);
+  border-radius: 3px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.10);
+  margin: 0 10px;
+}
+
+.cond-row__fill {
+  height: 100%;
+  border-radius: 3px;
+}
+
+.cond-row__fill--excellent { background: var(--earn); }
+.cond-row__fill--good      { background: var(--earn); }
+.cond-row__fill--fair      { background: var(--energy-color); }
+.cond-row__fill--poor      { background: var(--spend); }
+.cond-row__fill--broken    { background: var(--spend); }
+
+.cond-row__rating {
+  font-size: 0.72rem;
+  font-weight: 600;
+  width: 80px;
+  flex-shrink: 0;
+  white-space: nowrap;
+  text-shadow: var(--shadow-text);
+}
+
+.cond-row__rating--excellent { color: var(--earn); }
+.cond-row__rating--good      { color: var(--earn); }
+.cond-row__rating--fair      { color: var(--energy-color); }
+.cond-row__rating--poor      { color: var(--spend); }
+.cond-row__rating--broken    { color: var(--spend); }
+
+/* ── Footer ── */
+.car-card__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: auto;
+  padding-top: 8px;
+  border-top: 1px solid var(--divider);
+}
+
+.car-card__fuel {
+  font-size: 0.78rem;
+  font-weight: 400;
+  color: var(--text-3);
+  text-shadow: var(--shadow-text);
+}
+
+.car-card__value {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--text-2);
+  text-shadow: var(--shadow-text);
+}
+
+/* ── Compact variant (multi-car list / listing cards) ── */
+.car-card--compact {
+  min-height: 0;
+}
+
+.car-card--compact .car-card__image {
+  width: 120px;
+  min-width: 120px;
+}
+
+.car-card--compact .car-card__info {
+  padding: 12px 16px;
+}
+
+.car-card--compact .car-card__name {
+  font-size: 0.9rem;
+  margin-bottom: 8px;
+}
+
+.car-card--compact .car-stats {
+  margin-bottom: 6px;
+}
+
+/* ── Selected highlight ── */
+.car-card--selected {
+  border-color: rgba(255, 255, 255, 0.22);
+  background: rgba(255, 255, 255, 0.09);
+}

--- a/src/ui/components/location/CarCard.tsx
+++ b/src/ui/components/location/CarCard.tsx
@@ -1,0 +1,120 @@
+import type { OwnedCar, CarDefinition, ConditionRating } from '@engine/types';
+import { getConditionRating } from '@engine/index';
+import './CarCard.css';
+
+interface CarCardProps {
+  car: OwnedCar;
+  carDef: CarDefinition;
+  estimatedValue: number;
+  compact?: boolean;
+  selected?: boolean;
+  onClick?: () => void;
+}
+
+const RATING_LABELS: Record<ConditionRating, string> = {
+  excellent: 'Excellent',
+  good: 'Good',
+  fair: 'Fair',
+  poor: 'Poor',
+  scrap: 'Broken',
+};
+
+function conditionClass(rating: ConditionRating): string {
+  if (rating === 'scrap') return 'broken';
+  return rating;
+}
+
+function conditionWidth(value: number): string {
+  // Broken shows a sliver, not 0
+  if (value <= 0) return '2px';
+  return `${value}%`;
+}
+
+export function CarCard({
+  car,
+  carDef,
+  estimatedValue,
+  compact = false,
+  selected = false,
+  onClick,
+}: CarCardProps) {
+  const engineRating = getConditionRating(car.engineCondition);
+  const bodyRating = getConditionRating(car.bodyCondition);
+  const carName = `${carDef.year} ${carDef.make} ${carDef.model}`;
+  const hasImage = carDef.imageUrl !== '';
+
+  return (
+    <div
+      className={`car-card${compact ? ' car-card--compact' : ''}${selected ? ' car-card--selected' : ''}`}
+      onClick={onClick}
+      style={onClick ? { cursor: 'pointer' } : undefined}
+    >
+      {/* Image */}
+      <div className="car-card__image">
+        {hasImage ? (
+          <>
+            <div
+              className="car-card__image-bg"
+              style={{ backgroundImage: `url('${carDef.imageUrl}')` }}
+            />
+            <div className="car-card__image-fade" />
+          </>
+        ) : (
+          <>
+            <div className="car-card__image-fade" />
+            <div className="car-card__image-placeholder">No image available</div>
+          </>
+        )}
+      </div>
+
+      {/* Info */}
+      <div className="car-card__info">
+        <div className="car-card__name">{carName}</div>
+
+        {!compact && carDef.bio && (
+          <div className="car-card__bio">{carDef.bio}</div>
+        )}
+
+        <div className="car-stats">
+          <div className="cond-row">
+            <span className="cond-row__label">Engine</span>
+            <div className="cond-row__track">
+              <div
+                className={`cond-row__fill cond-row__fill--${conditionClass(engineRating)}`}
+                style={{ width: conditionWidth(car.engineCondition) }}
+              />
+            </div>
+            <span className={`cond-row__rating cond-row__rating--${conditionClass(engineRating)}`}>
+              {car.engineCondition <= 0
+                ? 'Broken'
+                : `${Math.round(car.engineCondition)}% \u00B7 ${RATING_LABELS[engineRating]}`}
+            </span>
+          </div>
+          <div className="cond-row">
+            <span className="cond-row__label">Body</span>
+            <div className="cond-row__track">
+              <div
+                className={`cond-row__fill cond-row__fill--${conditionClass(bodyRating)}`}
+                style={{ width: conditionWidth(car.bodyCondition) }}
+              />
+            </div>
+            <span className={`cond-row__rating cond-row__rating--${conditionClass(bodyRating)}`}>
+              {car.bodyCondition <= 0
+                ? 'Broken'
+                : `${Math.round(car.bodyCondition)}% \u00B7 ${RATING_LABELS[bodyRating]}`}
+            </span>
+          </div>
+        </div>
+
+        <div className="car-card__footer">
+          <span className="car-card__fuel">
+            Fuel: {Math.round(car.fuel)} / {car.fuelCapacity} L
+          </span>
+          <span className="car-card__value">
+            {compact ? `Est. ~$${estimatedValue}` : `Est. value ~$${estimatedValue}`}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/location/CarSelector.css
+++ b/src/ui/components/location/CarSelector.css
@@ -1,0 +1,107 @@
+/* ==========================================================================
+   Car Selector Chip + Dropdown (Mockup 7)
+   ========================================================================== */
+
+.car-selector-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 16px;
+  position: relative;
+}
+
+.car-selector-label {
+  font-size: 0.75rem;
+  font-weight: 400;
+  color: var(--text-3);
+  text-shadow: var(--shadow-text);
+  flex-shrink: 0;
+}
+
+.car-selector-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  background: var(--glass-3-bg);
+  border: var(--glass-3-border);
+  border-radius: 6px;
+  color: var(--text-1);
+  font-family: var(--font-sans);
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  text-shadow: var(--shadow-text);
+}
+
+.car-selector-btn:hover {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.14);
+}
+
+.car-selector-btn__arrow {
+  font-size: 0.7rem;
+  color: var(--text-3);
+  margin-left: 2px;
+}
+
+/* ── Dropdown ── */
+.car-dropdown {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  min-width: 256px;
+  background: var(--glass-1-bg);
+  backdrop-filter: blur(var(--glass-1-blur));
+  -webkit-backdrop-filter: blur(var(--glass-1-blur));
+  border: var(--glass-1-border);
+  border-radius: 10px;
+  box-shadow: var(--glass-1-shadow);
+  padding: 6px;
+  z-index: 50;
+  animation: carDropdownIn 0.15s ease-out;
+}
+
+@keyframes carDropdownIn {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.car-option {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 8px 12px;
+  border-radius: 7px;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.car-option:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.car-option--active {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.car-option__name {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text-1);
+  text-shadow: var(--shadow-text);
+}
+
+.car-option__stats {
+  font-size: 0.75rem;
+  font-weight: 400;
+  color: var(--text-3);
+  text-shadow: var(--shadow-text);
+}
+
+.car-option__check {
+  margin-left: auto;
+  font-size: 0.75rem;
+  color: var(--earn);
+}

--- a/src/ui/components/location/CarSelector.tsx
+++ b/src/ui/components/location/CarSelector.tsx
@@ -1,0 +1,90 @@
+import { useState, useRef, useEffect } from 'react';
+import type { OwnedCar, CarDefinition, ConditionRating } from '@engine/types';
+import { getConditionRating } from '@engine/index';
+import './CarSelector.css';
+
+interface CarSelectorProps {
+  cars: OwnedCar[];
+  carDefs: Map<string, CarDefinition>;
+  selectedId: string;
+  onSelect: (instanceId: string) => void;
+}
+
+const RATING_LABELS: Record<ConditionRating, string> = {
+  excellent: 'Excellent',
+  good: 'Good',
+  fair: 'Fair',
+  poor: 'Poor',
+  scrap: 'Broken',
+};
+
+export function CarSelector({ cars, carDefs, selectedId, onSelect }: CarSelectorProps) {
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef<HTMLDivElement>(null);
+
+  const selectedCar = cars.find((c) => c.instanceId === selectedId);
+  const selectedDef = selectedCar ? carDefs.get(selectedCar.carId) : undefined;
+  const selectedName = selectedDef
+    ? `${selectedDef.year} ${selectedDef.make} ${selectedDef.model}`
+    : 'Select a car';
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  return (
+    <div className="car-selector-row" ref={wrapRef}>
+      <span className="car-selector-label">Working on</span>
+      <div style={{ position: 'relative' }}>
+        <button
+          className="car-selector-btn"
+          onClick={() => setOpen((v) => !v)}
+        >
+          <span>{selectedName}</span>
+          <span className="car-selector-btn__arrow">{'\u25BE'}</span>
+        </button>
+
+        {open && (
+          <div className="car-dropdown">
+            {cars.map((car) => {
+              const def = carDefs.get(car.carId);
+              if (!def) return null;
+              const name = `${def.year} ${def.make} ${def.model}`;
+              const engineRating = getConditionRating(car.engineCondition);
+              const bodyRating = getConditionRating(car.bodyCondition);
+              const isActive = car.instanceId === selectedId;
+              return (
+                <div
+                  key={car.instanceId}
+                  className={`car-option${isActive ? ' car-option--active' : ''}`}
+                  onClick={() => {
+                    onSelect(car.instanceId);
+                    setOpen(false);
+                  }}
+                >
+                  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                    <div>
+                      <div className="car-option__name">{name}</div>
+                      <div className="car-option__stats">
+                        Engine: {RATING_LABELS[engineRating]} {'\u00B7'} Body: {RATING_LABELS[bodyRating]}
+                      </div>
+                    </div>
+                    {isActive && <span className="car-option__check">{'\u2713'}</span>}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/location/index.ts
+++ b/src/ui/components/location/index.ts
@@ -1,2 +1,5 @@
 export { ActivityCard } from './ActivityCard';
 export { ActivityModal } from './ActivityModal';
+export { CarCard } from './CarCard';
+export { CarSelector } from './CarSelector';
+export { BrowseResultsModal } from './BrowseResultsModal';

--- a/src/ui/screens/GameScreen.css
+++ b/src/ui/screens/GameScreen.css
@@ -297,6 +297,26 @@
   margin: 20px 0;
 }
 
+/* ── Car feature area ── */
+.car-feature {
+  margin-bottom: 20px;
+}
+
+.section-label {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--text-3);
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  margin-bottom: 12px;
+}
+
+.cars-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
 /* ── Stranded notice ── */
 .stranded-notice {
   padding: 1.6rem;

--- a/src/ui/screens/GameScreen.tsx
+++ b/src/ui/screens/GameScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useGameStore } from '@store/index';
 import { LocationList } from '@ui/components/map';
 import { ActivityCard, ActivityModal, CarCard, CarSelector, BrowseResultsModal } from '@ui/components/location';
@@ -90,14 +90,11 @@ export function GameScreen({
   );
 
   // Build a lookup of car definitions for cars at this location
-  const carDefsMap = useMemo(() => {
-    const map = new Map<string, CarDefinition>();
-    for (const car of carsHere) {
-      const def = getCarDefinition(car.carId);
-      if (def) map.set(car.carId, def);
-    }
-    return map;
-  }, [carsHere]);
+  const carDefsMap = new Map<string, CarDefinition>();
+  for (const car of carsHere) {
+    const def = getCarDefinition(car.carId);
+    if (def) carDefsMap.set(car.carId, def);
+  }
 
   // Auto-select first car when location changes or selection becomes invalid
   useEffect(() => {
@@ -112,13 +109,13 @@ export function GameScreen({
   }, [gameState.player.position.x, gameState.player.position.y, carsHere.length]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Estimate car value based on average condition rating
-  const estimateCarValue = useCallback((car: typeof carsHere[number]) => {
+  const estimateCarValue = (car: typeof carsHere[number]) => {
     const def = carDefsMap.get(car.carId);
     if (!def) return 0;
     const avg = (car.engineCondition + car.bodyCondition) / 2;
     const rating = getConditionRating(Math.round(avg));
     return def.marketValue[rating];
-  }, [carDefsMap]);
+  };
 
   // Watch for listings_shown events to open browse modal
   useEffect(() => {

--- a/src/ui/screens/GameScreen.tsx
+++ b/src/ui/screens/GameScreen.tsx
@@ -1,17 +1,21 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useGameStore } from '@store/index';
 import { LocationList } from '@ui/components/map';
-import { ActivityCard, ActivityModal } from '@ui/components/location';
+import { ActivityCard, ActivityModal, CarCard, CarSelector, BrowseResultsModal } from '@ui/components/location';
 import { PauseMenu, ToastContainer, NewspaperModal } from '@ui/components/common';
 import {
   getLocationActivities,
   getLocationAtPosition,
   canPerformActivity,
+  getCarDefinition,
+  getConditionRating,
   MAX_ENERGY,
   STAT_ORDER,
   getTimeOfDay,
   type ActivityDefinition,
   type LocationDefinition,
+  type CarDefinition,
+  type CarListing,
 } from '@engine/index';
 import './GameScreen.css';
 
@@ -41,9 +45,14 @@ export function GameScreen({
   const takeGig = useGameStore((state) => state.takeGig);
   const muted = useGameStore((state) => state.muted);
   const toggleMute = useGameStore((state) => state.toggleMute);
+  const selectedCarInstanceId = useGameStore((state) => state.selectedCarInstanceId);
+  const setSelectedCarInstanceId = useGameStore((state) => state.setSelectedCarInstanceId);
+  const pendingEvents = useGameStore((state) => state.pendingEvents);
+  const clearEvents = useGameStore((state) => state.clearEvents);
 
   const [showPauseMenu, setShowPauseMenu] = useState(false);
   const [showNewspaper, setShowNewspaper] = useState(false);
+  const [browseListings, setBrowseListings] = useState<CarListing[] | null>(null);
 
   const newspaperPurchasedToday =
     gameState.newspaper.purchased &&
@@ -73,6 +82,53 @@ export function GameScreen({
       car.engineCondition > 0
   );
 
+  // All cars at the player's current position (regardless of condition)
+  const carsHere = gameState.inventory.cars.filter(
+    (car) =>
+      car.position.x === gameState.player.position.x &&
+      car.position.y === gameState.player.position.y
+  );
+
+  // Build a lookup of car definitions for cars at this location
+  const carDefsMap = useMemo(() => {
+    const map = new Map<string, CarDefinition>();
+    for (const car of carsHere) {
+      const def = getCarDefinition(car.carId);
+      if (def) map.set(car.carId, def);
+    }
+    return map;
+  }, [carsHere]);
+
+  // Auto-select first car when location changes or selection becomes invalid
+  useEffect(() => {
+    if (carsHere.length === 0) {
+      if (selectedCarInstanceId !== null) setSelectedCarInstanceId(null);
+      return;
+    }
+    const stillHere = carsHere.some((c) => c.instanceId === selectedCarInstanceId);
+    if (!stillHere) {
+      setSelectedCarInstanceId(carsHere[0].instanceId);
+    }
+  }, [gameState.player.position.x, gameState.player.position.y, carsHere.length]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Estimate car value based on average condition rating
+  const estimateCarValue = useCallback((car: typeof carsHere[number]) => {
+    const def = carDefsMap.get(car.carId);
+    if (!def) return 0;
+    const avg = (car.engineCondition + car.bodyCondition) / 2;
+    const rating = getConditionRating(Math.round(avg));
+    return def.marketValue[rating];
+  }, [carDefsMap]);
+
+  // Watch for listings_shown events to open browse modal
+  useEffect(() => {
+    const listingsEvent = pendingEvents.find((e) => e.type === 'listings_shown');
+    if (listingsEvent?.data?.listings) {
+      setBrowseListings(listingsEvent.data.listings as CarListing[]);
+      clearEvents();
+    }
+  }, [pendingEvents, clearEvents]);
+
   // Background image for current location or map
   const bgImage = currentTab === 'map'
     ? 'map.jpg'
@@ -86,9 +142,12 @@ export function GameScreen({
   const handleActivityExecute = useCallback(
     (params: { hours?: number }) => {
       if (!selectedActivity) return;
-      return performActivity(selectedActivity.id, params);
+      return performActivity(selectedActivity.id, {
+        ...params,
+        selectedCarInstanceId: selectedCarInstanceId ?? undefined,
+      });
     },
-    [selectedActivity, performActivity]
+    [selectedActivity, performActivity, selectedCarInstanceId]
   );
 
   const handleModalClose = () => {
@@ -163,7 +222,7 @@ export function GameScreen({
   const energyPct = (gameState.player.energy / MAX_ENERGY) * 100;
 
   return (
-    <div className={`game-screen game-screen--${timeOfDay}${showPauseMenu || selectedActivity || showNewspaper ? ' game-screen--modal-open' : ''}`}>
+    <div className={`game-screen game-screen--${timeOfDay}${showPauseMenu || selectedActivity || showNewspaper || browseListings ? ' game-screen--modal-open' : ''}`}>
       {/* Background */}
       <div className="bg">
         <div
@@ -267,11 +326,58 @@ export function GameScreen({
               <div className="content-area">
                 {currentLocation ? (
                   <>
+                    {/* Car card — shows when player has cars at this location */}
+                    {carsHere.length === 1 && (() => {
+                      const car = carsHere[0];
+                      const def = carDefsMap.get(car.carId);
+                      if (!def) return null;
+                      return (
+                        <div className="car-feature">
+                          <div className="section-label">YOUR CAR</div>
+                          <CarCard car={car} carDef={def} estimatedValue={estimateCarValue(car)} />
+                        </div>
+                      );
+                    })()}
+
+                    {/* Multi-car display + selector chip */}
+                    {carsHere.length > 1 && (
+                      <>
+                        <div className="car-feature">
+                          <div className="section-label">YOUR CARS HERE</div>
+                          <div className="cars-list">
+                            {carsHere.map((car) => {
+                              const def = carDefsMap.get(car.carId);
+                              if (!def) return null;
+                              return (
+                                <CarCard
+                                  key={car.instanceId}
+                                  car={car}
+                                  carDef={def}
+                                  estimatedValue={estimateCarValue(car)}
+                                  compact
+                                  selected={car.instanceId === selectedCarInstanceId}
+                                  onClick={() => setSelectedCarInstanceId(car.instanceId)}
+                                />
+                              );
+                            })}
+                          </div>
+                        </div>
+                        <CarSelector
+                          cars={carsHere}
+                          carDefs={carDefsMap}
+                          selectedId={selectedCarInstanceId ?? carsHere[0].instanceId}
+                          onSelect={setSelectedCarInstanceId}
+                        />
+                      </>
+                    )}
+
                     {/* Location-specific activities */}
                     {locationSpecific.length > 0 && (
                       <div className="activities-grid">
                         {locationSpecific.map((activity) => {
-                          const check = canPerformActivity(gameState, activity.id);
+                          const check = canPerformActivity(gameState, activity.id, {
+                            selectedCarInstanceId: selectedCarInstanceId ?? undefined,
+                          });
                           return (
                             <ActivityCard
                               key={activity.id}
@@ -362,6 +468,15 @@ export function GameScreen({
           currentDay={gameState.time.currentDay}
           onTakeGig={handleTakeGig}
           onClose={handleCloseNewspaper}
+        />
+      )}
+
+      {/* Browse Results Modal — triggered by browse_junkers activity */}
+      {browseListings && (
+        <BrowseResultsModal
+          listings={browseListings}
+          currentDay={gameState.time.currentDay}
+          onClose={() => setBrowseListings(null)}
         />
       )}
 


### PR DESCRIPTION
## Summary
- **Car card component** — full-width Tier 2 glass panel showing car image, name, bio, engine/body condition bars (colour-coded by rating), fuel readout, and estimated value. Compact variant for multi-car lists. No-image fallback with italic placeholder.
- **Car selection chip** — "Working on: [Car Name] ▾" dropdown above activity cards when >1 car at current location. Auto-selects first car, resets on location change. Selection drives `selectedCarInstanceId` passed to all activity executions.
- **Browse results modal** — 560px Tier 1 glass modal triggered by `browse_junkers` `listings_shown` event. Listing cards with 120px image, condition badges (coloured pills), asking price, expiry. Footer note: "Come back with cash to negotiate." No buy button (Phase 4).
- **Disabled card state** — `.card__locked` text now uses `--spend` red per mockup.

Design source: `design/mockup-7-car-cards.html`. All styling uses CSS custom properties from `tokens.css`.

## Test plan
- [ ] Start new game, navigate to Garage — car card shows starter Commodore with broken engine / poor body
- [ ] Verify no-image placeholder renders ("No image available")
- [ ] Condition bars colour-coded: green (good/excellent), amber (fair), red (poor/broken)
- [ ] Navigate to Scrapyard, run Browse Junkers — browse modal opens with 3–5 listing cards
- [ ] Close browse modal — game resumes normally
- [ ] Acquire a second car, go to Garage — car selector chip appears, both car cards render
- [ ] Selecting a different car in dropdown updates the "Working on" label and highlighted card
- [ ] Disabled activities show locked text in red
- [ ] All new CSS uses only design tokens — no hardcoded values