### PR TITLE
fix: Phase 3 bugfixes + tow activity

### DIFF
--- a/data/activities/garage.json
+++ b/data/activities/garage.json
@@ -160,6 +160,37 @@
       ],
       "statGain": [],
       "risks": []
+    },
+    {
+      "id": "tow_car_to_garage",
+      "name": "Tow Car Here",
+      "description": "Pay a tow truck to bring your car to the garage.",
+      "category": "transport",
+      "time": {
+        "type": "fixed",
+        "hours": 1
+      },
+      "energy": {
+        "type": "fixed",
+        "base": 3
+      },
+      "money": {
+        "type": "spend",
+        "mode": "fixed",
+        "base": 150
+      },
+      "prerequisites": [
+        {
+          "type": "hasCarElsewhere"
+        }
+      ],
+      "outcomes": [
+        {
+          "type": "towCar"
+        }
+      ],
+      "statGain": [],
+      "risks": []
     }
   ]
 }

--- a/src/engine/core/activity.ts
+++ b/src/engine/core/activity.ts
@@ -346,6 +346,29 @@ export function executeActivity(input: ExecuteActivityInput): ActivityResult {
         break;
       }
 
+      case 'towCar': {
+        // Find the first car not at the player's current position
+        const carToTow = state.inventory.cars.find(
+          (c) =>
+            c.position.x !== state.player.position.x ||
+            c.position.y !== state.player.position.y
+        );
+        if (carToTow) {
+          const carDef = getCarDefinition(carToTow.carId);
+          const carName = carDef ? `${carDef.year} ${carDef.make} ${carDef.model}` : 'your car';
+          carUpdates.push({
+            instanceId: carToTow.instanceId,
+            position: { ...state.player.position },
+          });
+          events.push({
+            type: 'car_towed',
+            message: `${carName} has been towed here.`,
+            data: { instanceId: carToTow.instanceId },
+          });
+        }
+        break;
+      }
+
       case 'conditionalCost':
         events.push({
           type: 'conditional_cost',
@@ -510,7 +533,7 @@ export function canPerformActivity(
   // Check energy
   const energyCost = calculateEnergyCost(state, activity, params);
   if (state.player.energy < energyCost) {
-    return { canPerform: false, reason: `Need ${energyCost} energy` };
+    return { canPerform: false, reason: `Requires ${energyCost} energy.` };
   }
 
   // Check money — mirror the variable-cost pre-computation from executeActivity
@@ -527,7 +550,7 @@ export function canPerformActivity(
     }
   }
   if (state.player.money < moneyCost) {
-    return { canPerform: false, reason: `Need $${moneyCost}` };
+    return { canPerform: false, reason: `You need $${moneyCost}.` };
   }
 
   return { canPerform: true };

--- a/src/engine/data/index.ts
+++ b/src/engine/data/index.ts
@@ -57,7 +57,7 @@ export interface StatModifier {
 }
 
 export interface Prerequisite {
-  type: 'money' | 'stat' | 'item' | 'license' | 'ownership' | 'context' | 'hasCarHere';
+  type: 'money' | 'stat' | 'item' | 'license' | 'ownership' | 'context' | 'hasCarHere' | 'hasCarElsewhere';
   minimum?: number | string;
   stat?: keyof PlayerStats;
   requirement?: string;
@@ -65,7 +65,7 @@ export interface Prerequisite {
 }
 
 export interface Outcome {
-  type: 'items' | 'showListings' | 'acquireCar' | 'removeCar' | 'conditionalCost' | 'resetFoodCounter' | 'refuelCar' | 'generateNewspaper' | 'repairEngine' | 'repairBody' | 'replaceEngine';
+  type: 'items' | 'showListings' | 'acquireCar' | 'removeCar' | 'conditionalCost' | 'resetFoodCounter' | 'refuelCar' | 'generateNewspaper' | 'repairEngine' | 'repairBody' | 'replaceEngine' | 'towCar';
   itemType?: string;
   quantity?: { min: number; max: number };
   statModifier?: StatModifier;

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -342,6 +342,7 @@ export interface StateDelta {
     fuel?: number;
     engineCondition?: number;
     bodyCondition?: number;
+    position?: GridPosition;
   }>;
   removedCarInstanceId?: string;
   marketUpdates?: Partial<Market>;
@@ -367,6 +368,7 @@ export type GameEventType =
   | 'gig_completed'
   | 'car_repaired'
   | 'car_scrapped'
+  | 'car_towed'
   | 'engine_replaced';
 
 export interface GameEvent {

--- a/src/engine/utils/validators.ts
+++ b/src/engine/utils/validators.ts
@@ -7,6 +7,8 @@ import type { GameState } from '../types';
 import type { Prerequisite } from '../data';
 import type { ActivityParams } from './calculations';
 
+const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
+
 /**
  * Result of a validation check
  */
@@ -61,10 +63,11 @@ function checkSinglePrerequisite(
     case 'hasCarHere':
       return checkHasCarHere(state);
 
+    case 'hasCarElsewhere':
+      return checkHasCarElsewhere(state);
+
     case 'context':
-      // Context prerequisites are handled at the UI level
-      // For now, always pass
-      return { valid: true };
+      return checkContextPrerequisite(prereq);
 
     default:
       return { valid: true };
@@ -73,19 +76,16 @@ function checkSinglePrerequisite(
 
 /**
  * Check if player has enough money.
+ * Dynamic references (e.g. "carPrice") are deferred to execution time.
  */
 function checkMoneyPrerequisite(
   state: GameState,
   prereq: Prerequisite
 ): ValidationResult {
   if (typeof prereq.minimum === 'string') {
-    // Dynamic money prerequisites (e.g. "carPrice") require context that
-    // isn't available yet. Fail with a descriptive message rather than
-    // silently treating the minimum as 0.
-    return {
-      valid: false,
-      reason: `Cannot determine cost: ${prereq.minimum} is not yet available.`,
-    };
+    // Dynamic money prerequisites (e.g. "carPrice") can't be resolved at
+    // card-display time — defer to execution.
+    return { valid: true };
   }
 
   const minimum = prereq.minimum ?? 0;
@@ -93,7 +93,7 @@ function checkMoneyPrerequisite(
   if (state.player.money < minimum) {
     return {
       valid: false,
-      reason: `Not enough money. Need $${minimum}, have $${state.player.money}.`,
+      reason: `You need at least $${minimum}.`,
     };
   }
 
@@ -117,7 +117,7 @@ function checkStatPrerequisite(
   if (currentLevel < minimum) {
     return {
       valid: false,
-      reason: `${prereq.stat} too low. Need ${minimum}, have ${currentLevel}.`,
+      reason: `You need at least ${minimum} ${capitalize(prereq.stat)} skill.`,
     };
   }
 
@@ -138,7 +138,7 @@ function checkLicensePrerequisite(
   if (!state.player.licenses.includes(prereq.requirement)) {
     return {
       valid: false,
-      reason: `Missing license: ${prereq.requirement}`,
+      reason: `Requires a ${prereq.requirement} license.`,
     };
   }
 
@@ -206,7 +206,7 @@ function checkItemPrerequisite(
       if (state.inventory.engineParts < minimum) {
         return {
           valid: false,
-          reason: `Not enough engine parts. Need ${minimum}, have ${state.inventory.engineParts}.`,
+          reason: `Requires engine parts \u2014 you have ${state.inventory.engineParts}.`,
         };
       }
       break;
@@ -215,7 +215,7 @@ function checkItemPrerequisite(
       if (state.inventory.bodyParts < minimum) {
         return {
           valid: false,
-          reason: `Not enough body parts. Need ${minimum}, have ${state.inventory.bodyParts}.`,
+          reason: `Requires body parts \u2014 you have ${state.inventory.bodyParts}.`,
         };
       }
       break;
@@ -245,6 +245,41 @@ function checkHasCarHere(state: GameState): ValidationResult {
 }
 
 /**
+ * Check if the player has a car at a different position (for tow).
+ */
+function checkHasCarElsewhere(state: GameState): ValidationResult {
+  const hasCarElsewhere = state.inventory.cars.some(
+    (car) =>
+      car.position.x !== state.player.position.x ||
+      car.position.y !== state.player.position.y
+  );
+
+  if (!hasCarElsewhere) {
+    return {
+      valid: false,
+      reason: 'All your cars are already here.',
+    };
+  }
+
+  return { valid: true };
+}
+
+/**
+ * Check context prerequisites — gate on runtime context that the UI
+ * must supply (e.g. a selected car listing).
+ */
+function checkContextPrerequisite(prereq: Prerequisite): ValidationResult {
+  if (prereq.requirement === 'selectedCar') {
+    return {
+      valid: false,
+      reason: 'Browse junkers first to select a car.',
+    };
+  }
+
+  return { valid: true };
+}
+
+/**
  * Check if player has enough energy for an activity.
  */
 export function checkEnergyAvailable(
@@ -254,7 +289,7 @@ export function checkEnergyAvailable(
   if (state.player.energy < requiredEnergy) {
     return {
       valid: false,
-      reason: `Not enough energy. Need ${requiredEnergy}, have ${state.player.energy}.`,
+      reason: `Requires ${requiredEnergy} energy.`,
     };
   }
 
@@ -271,7 +306,7 @@ export function checkMoneyAvailable(
   if (state.player.money < requiredMoney) {
     return {
       valid: false,
-      reason: `Not enough money. Need $${requiredMoney}, have $${state.player.money}.`,
+      reason: `You need $${requiredMoney}.`,
     };
   }
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -256,6 +256,7 @@ function applyDelta(state: GameState, delta: StateDelta): GameState {
             bodyCondition: update.bodyCondition !== undefined
               ? Math.max(0, Math.min(100, update.bodyCondition))
               : car.bodyCondition,
+            position: update.position ?? car.position,
           };
         })
       : state.inventory.cars;

--- a/src/ui/components/location/ActivityModal.tsx
+++ b/src/ui/components/location/ActivityModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import type { ActivityDefinition } from '@engine/index';
 import { useGameStore } from '@store/index';
 import './ActivityModal.css';
@@ -47,6 +47,7 @@ export function ActivityModal({
   const [phase, setPhase] = useState<ModalPhase>(isVariableTime ? 'hours' : 'progress');
   const [hours, setHours] = useState(minHours);
   const [result, setResult] = useState<ActivityResult | null>(null);
+  const executedRef = useRef(false);
 
   const actualHours = isVariableTime ? hours : fixedHours;
 
@@ -61,9 +62,11 @@ export function ActivityModal({
     setPhase('progress');
   }, [isVariableTime, hours, onExecute, triggerAudioEvent]);
 
-  // Auto-execute for fixed-time activities on mount
+  // Auto-execute for fixed-time activities on mount.
+  // Guard with ref to prevent StrictMode double-execution.
   useEffect(() => {
-    if (!isVariableTime) {
+    if (!isVariableTime && !executedRef.current) {
+      executedRef.current = true;
       const params = {};
       const res = onExecute(params);
       if (res && typeof res === 'object') {

--- a/src/ui/screens/GameScreen.tsx
+++ b/src/ui/screens/GameScreen.tsx
@@ -117,14 +117,16 @@ export function GameScreen({
     return def.marketValue[rating];
   };
 
-  // Watch for listings_shown events to open browse modal
+  // Watch for listings_shown events to open browse modal.
+  // Close the activity modal first so the progress bar doesn't linger behind.
   useEffect(() => {
     const listingsEvent = pendingEvents.find((e) => e.type === 'listings_shown');
     if (listingsEvent?.data?.listings) {
+      setSelectedActivity(null);
       setBrowseListings(listingsEvent.data.listings as CarListing[]);
       clearEvents();
     }
-  }, [pendingEvents, clearEvents]);
+  }, [pendingEvents, clearEvents, setSelectedActivity]);
 
   // Background image for current location or map
   const bgImage = currentTab === 'map'


### PR DESCRIPTION
## Summary
- Fix 5 implementation bugs from Phase 3 testing (scrap success message, browse junkers prereq, player-facing messages, energy check timing, loading on modal close)
- Add `tow_car_to_garage` activity to unblock the starter-car soft-lock
- Align `canPerformActivity` energy/money messages with validator rewrites (review fix)

## Files changed
- `data/activities/garage.json` — tow activity definition
- `src/engine/core/activity.ts` — towCar outcome, message alignment
- `src/engine/data/index.ts` — hasCarElsewhere prereq, towCar outcome type
- `src/engine/types.ts` — position in carUpdates, car_towed event
- `src/engine/utils/validators.ts` — player-facing messages, hasCarElsewhere, context prereq
- `src/store/index.ts` — position in applyDelta
- `src/ui/components/location/ActivityModal.tsx` — StrictMode double-execution guard
- `src/ui/screens/GameScreen.tsx` — close activity modal on browse listings