### PR TITLE
fix: Phase 3 round 2 bugfixes + travel confirm + nap buff

### DIFF
--- a/Shitbox_Architecture.md
+++ b/Shitbox_Architecture.md
@@ -89,6 +89,11 @@ shitbox/
 │   ├── main.ts                 # Electron main process
 │   └── preload.ts              # IPC bridge
 │
+├── public/
+│   └── assets/
+│       ├── audio/              # BGM (time-of-day tracks), jingles, title music
+│       └── backgrounds/        # Location/UI background photos (JPG)
+│
 ├── src/
 │   ├── index.tsx               # React entry point
 │   ├── index.css               # Global styles
@@ -96,8 +101,8 @@ shitbox/
 │   ├── App.tsx                 # Root component, router
 │   ├── vite-env.d.ts
 │   │
-│   ├── assets/
-│   │   └── backgrounds/        # 18 location/UI background photos (JPG)
+│   ├── hooks/
+│   │   └── useAudio.ts         # Audio playback hook (BGM, jingles)
 │   │
 │   ├── engine/                 # PURE GAME LOGIC (no React)
 │   │   ├── index.ts            # Public API
@@ -109,6 +114,7 @@ shitbox/
 │   │   │   ├── index.ts        # Data loading
 │   │   │   └── map.ts          # Map data helpers
 │   │   ├── systems/
+│   │   │   ├── newspaper.ts    # Newspaper generation & gig execution
 │   │   │   └── travel.ts       # Travel logic
 │   │   └── utils/
 │   │       ├── rng.ts          # Seeded random number generator
@@ -120,10 +126,10 @@ shitbox/
 │   │
 │   └── ui/                     # REACT COMPONENTS
 │       ├── components/
-│       │   ├── common/         # ConfirmDialog, FadeTransition, HoursSlider, LoadGameDialog, PauseMenu, Toast
+│       │   ├── common/         # BackgroundSlideshow, ConfirmDialog, FadeTransition, HoursSlider, LoadGameDialog, NewspaperModal, PauseMenu, Toast
 │       │   ├── game/           # ActivityPanel, EventLog, GameHeader, GameHUD
 │       │   ├── hud/            # AnimatedClock, AnimatedEnergy, AnimatedMoney, Sidebar
-│       │   ├── location/       # ActivityCard, ActivityModal
+│       │   ├── location/       # ActivityCard, ActivityModal, BrowseResultsModal, CarCard, CarSelector
 │       │   └── map/            # LocationCard, LocationList
 │       └── screens/
 │           ├── MainMenu.tsx
@@ -133,19 +139,27 @@ shitbox/
 │           └── PlaceholderScreen.tsx
 │
 ├── data/                       # JSON CONFIG FILES
+│   ├── cars.json               # Car definitions (tiers 0-4, 11 cars incl. victory car)
 │   ├── economy.json            # Base economic values
 │   ├── map.json                # Location definitions, regions, travel costs
+│   ├── newspaper-templates.json # Headline and gig templates
 │   └── activities/
-│       ├── scrapyard.json
+│       ├── car_wash.json
+│       ├── garage.json         # Repair activities + tow
 │       ├── gas_station.json
-│       └── misc.json           # Universal activities (nap, sleep, etc.)
+│       ├── misc.json           # Universal activities (nap, sleep, etc.)
+│       ├── scrapyard.json
+│       └── workshop.json       # Engine replacement (DIY + paid)
 │
 ├── design/                     # UI DESIGN REFERENCE
 │   ├── brand-guide.md          # Brand & design guide for implementers
 │   ├── mockup-1-scrapyard.html # Location screen mockup
 │   ├── mockup-2-map.html       # Map screen mockup
 │   ├── mockup-3-pause.html     # Pause menu mockup
-│   └── mockup-4-activity.html  # Activity modal mockup
+│   ├── mockup-4-activity.html  # Activity modal mockup
+│   ├── mockup-5-mainmenu.html  # Main menu mockup
+│   ├── mockup-6-newspaper.html # Newspaper modal mockup
+│   └── mockup-7-car-cards.html # Car card mockup
 │
 ├── saves/                      # Player save files (gitignored)
 │
@@ -1748,8 +1762,10 @@ export const useGameStore = create<GameStore>()(
 
 ### 5.2 Selectors
 
+> **Note:** `src/store/selectors.ts` does not exist yet. Selection logic is currently inline where needed. The reference implementation below is aspirational — to be extracted as complexity grows.
+
 ```typescript
-// src/store/selectors.ts
+// src/store/selectors.ts (planned)
 
 import { GameState, OwnedCar } from '../engine/types';
 import { getCarDefinition } from '../engine/data';
@@ -1852,17 +1868,17 @@ export const selectPassiveIncome = (state: GameState): number => {
 
 ---
 
-### Phase 2: World & Basic Activities (Weeks 4-5) ← CURRENT
+### Phase 2: World & Basic Activities (Weeks 4-5) ✓
 **Goal**: Navigate locations, perform work
 
 - [x] Build map screen with clickable locations
 - [x] Create location menu system
-- [ ] Implement activity UI (select, confirm, see results)
+- [x] Implement activity UI (select, confirm, see results)
 - [x] Add scrapyard activities (labor, scavenge)
-- [ ] Add basic car wash job
-- [ ] Implement inventory (parts)
-- [ ] Build time-of-day visuals
-- [ ] Add newspaper system (basic)
+- [x] Add basic car wash job
+- [x] Implement inventory (parts)
+- [x] Build time-of-day visuals
+- [x] Add newspaper system (basic)
 
 **Data files needed**:
 - `activities/scrapyard.json` ✓
@@ -1872,17 +1888,17 @@ export const selectPassiveIncome = (state: GameState): number => {
 
 ---
 
-### Phase 3: Cars & Garage (Weeks 6-7)
+### Phase 3: Cars & Garage (Weeks 6-7) ✓
 **Goal**: Own, store, and maintain cars
 
-- [ ] Implement car data structure
-- [ ] Build car card component
-- [ ] Create garage system (storage, basic repairs)
-- [ ] Implement engine/body condition
-- [ ] Add repair activities
-- [ ] Create workshop (major repairs, engine replacement)
-- [ ] Build parts usage system
-- [ ] Add car degradation over use
+- [x] Implement car data structure
+- [x] Build car card component
+- [x] Create garage system (storage, basic repairs)
+- [x] Implement engine/body condition
+- [x] Add repair activities
+- [x] Create workshop (major repairs, engine replacement)
+- [x] Build parts usage system
+- [x] Add car degradation over use
 
 **Data files needed**:
 - `cars.json` (start with 10-15 cars)
@@ -1893,7 +1909,7 @@ export const selectPassiveIncome = (state: GameState): number => {
 
 ---
 
-### Phase 4: Negotiation (Weeks 8-10)
+### Phase 4: Negotiation (Weeks 8-10) ← CURRENT
 **Goal**: Buy and sell through negotiation
 
 - [ ] Implement NPC generation with traits

--- a/data/activities/misc.json
+++ b/data/activities/misc.json
@@ -73,7 +73,7 @@
       "energy": {
         "type": "recover",
         "mode": "perHour",
-        "base": 2,
+        "base": 5,
         "statModifier": {
           "stat": "fitness",
           "effect": "increase",

--- a/src/engine/core/activity.ts
+++ b/src/engine/core/activity.ts
@@ -231,13 +231,22 @@ export function executeActivity(input: ExecuteActivityInput): ActivityResult {
 
       case 'showListings': {
         if (outcome.listingType === 'junker_cars') {
-          const listings = generateJunkerListings(state, rng);
-          marketUpdates = {
-            currentListings: [
-              ...state.market.currentListings.filter((l) => l.source !== 'scrapyard'),
-              ...listings,
-            ],
-          };
+          // Reuse existing scrapyard listings if they haven't expired
+          const existingListings = state.market.currentListings.filter(
+            (l) => l.source === 'scrapyard' && l.expiresDay > state.time.currentDay
+          );
+          const listings = existingListings.length > 0
+            ? existingListings
+            : generateJunkerListings(state, rng);
+
+          if (existingListings.length === 0) {
+            marketUpdates = {
+              currentListings: [
+                ...state.market.currentListings.filter((l) => l.source !== 'scrapyard'),
+                ...listings,
+              ],
+            };
+          }
           events.push({
             type: 'listings_shown',
             message: `You browse the yard and spot ${listings.length} vehicle${listings.length !== 1 ? 's' : ''}.`,

--- a/src/hooks/useAudio.ts
+++ b/src/hooks/useAudio.ts
@@ -12,8 +12,7 @@ const BGM_TRACKS: Record<TimePeriod, string[]> = {
 };
 
 const TITLE_TRACK = '/assets/audio/late-night-radio.mp3';
-const JINGLE_ACTIVITY = '/assets/audio/jingle-activity.wav';
-const JINGLE_TRAVEL = '/assets/audio/jingle-travel.wav';
+const JINGLE_TRAVEL = '/assets/audio/jingle-activity.wav';
 const FADE_MS = 600;
 
 export function useAudio() {
@@ -99,7 +98,7 @@ export function useAudio() {
   // Initialize audio elements + global autoplay unlock listener
   useEffect(() => {
     const bgm = new Audio();
-    bgm.loop = true;
+    bgm.loop = false;
     bgmRef.current = bgm;
     intendedSrc.current = '';
 
@@ -118,6 +117,28 @@ export function useAudio() {
     };
     document.addEventListener('click', onInteraction);
     document.addEventListener('keydown', onInteraction);
+
+    // When a BGM track ends, advance to the next track for the period
+    // (or loop if on the title screen).
+    const onBgmEnded = () => {
+      if (jinglePlaying.current) return;
+      const period = activePeriod.current;
+      if (!period) {
+        // Title screen — loop the same track
+        bgm.currentTime = 0;
+        bgm.play().catch(() => {});
+        return;
+      }
+      const tracks = BGM_TRACKS[period];
+      const idx = trackIdx.current[period];
+      trackIdx.current[period] = (idx + 1) % tracks.length;
+      intendedSrc.current = tracks[idx];
+      bgm.src = tracks[idx];
+      bgm.currentTime = 0;
+      bgm.volume = 1;
+      bgm.play().catch(() => {});
+    };
+    bgm.addEventListener('ended', onBgmEnded);
 
     // Shared resume logic — used by both onJingleEnd and activity_end handler.
     // Checks live time period to avoid resuming a stale track after a period
@@ -151,6 +172,7 @@ export function useAudio() {
     return () => {
       bgm.pause();
       jingle.pause();
+      bgm.removeEventListener('ended', onBgmEnded);
       jingle.removeEventListener('ended', onJingleEnd);
       document.removeEventListener('click', onInteraction);
       document.removeEventListener('keydown', onInteraction);
@@ -174,15 +196,14 @@ export function useAudio() {
     const jingle = jingleRef.current;
     if (!bgm || !jingle) return;
 
-    if (audioEvent === 'activity_start' || audioEvent === 'travel') {
+    if (audioEvent === 'travel') {
       savedSrc.current = intendedSrc.current;
       savedPos.current = bgm.currentTime;
       savedPeriod.current = activePeriod.current;
       jinglePlaying.current = true;
 
-      const jingleSrc = audioEvent === 'travel' ? JINGLE_TRAVEL : JINGLE_ACTIVITY;
       fadeBgmOut().then(() => {
-        jingle.src = jingleSrc;
+        jingle.src = JINGLE_TRAVEL;
         jingle.currentTime = 0;
         jingle.volume = 1;
         jingle.play().catch(() => {});

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -34,7 +34,7 @@ export interface ToastMessage {
   type: 'success' | 'error' | 'info' | 'earn' | 'spend';
 }
 
-export type AudioEvent = 'activity_start' | 'activity_end' | 'travel';
+export type AudioEvent = 'activity_end' | 'travel';
 
 type GameTab = 'location' | 'map';
 

--- a/src/ui/components/location/ActivityModal.tsx
+++ b/src/ui/components/location/ActivityModal.tsx
@@ -58,9 +58,8 @@ export function ActivityModal({
     if (res && typeof res === 'object') {
       setResult(res as ActivityResult);
     }
-    triggerAudioEvent('activity_start');
     setPhase('progress');
-  }, [isVariableTime, hours, onExecute, triggerAudioEvent]);
+  }, [isVariableTime, hours, onExecute]);
 
   // Auto-execute for fixed-time activities on mount.
   // Guard with ref to prevent StrictMode double-execution.
@@ -72,7 +71,6 @@ export function ActivityModal({
       if (res && typeof res === 'object') {
         setResult(res as ActivityResult);
       }
-      triggerAudioEvent('activity_start');
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/src/ui/components/map/LocationCard.tsx
+++ b/src/ui/components/map/LocationCard.tsx
@@ -11,20 +11,16 @@ interface LocationCardProps {
   location: LocationDefinition;
   playerPosition: GridPosition;
   playerFitness: number;
-  hasCarHere: boolean;
   isCurrentLocation: boolean;
-  onWalk: () => void;
-  onDrive: () => void;
+  onSelect: () => void;
 }
 
 export function LocationCard({
   location,
   playerPosition,
   playerFitness,
-  hasCarHere,
   isCurrentLocation,
-  onWalk,
-  onDrive,
+  onSelect,
 }: LocationCardProps) {
   const distanceMeters = calculateDistanceMeters(playerPosition, location.position);
   const walkTime = calculateTravelTime(playerPosition, location.position, 'walk');
@@ -37,12 +33,7 @@ export function LocationCard({
 
   const handleClick = () => {
     if (isCurrentLocation) return;
-    // Default action: walk if no car, drive if car available
-    if (hasCarHere) {
-      onDrive();
-    } else {
-      onWalk();
-    }
+    onSelect();
   };
 
   return (

--- a/src/ui/components/map/LocationList.tsx
+++ b/src/ui/components/map/LocationList.tsx
@@ -11,17 +11,13 @@ import './LocationList.css';
 interface LocationListProps {
   playerPosition: GridPosition;
   playerFitness: number;
-  hasCarHere: boolean;
-  onWalk: (location: LocationDefinition) => void;
-  onDrive: (location: LocationDefinition) => void;
+  onSelect: (location: LocationDefinition) => void;
 }
 
 export function LocationList({
   playerPosition,
   playerFitness,
-  hasCarHere,
-  onWalk,
-  onDrive,
+  onSelect,
 }: LocationListProps) {
   const locationsByRegion = getLocationsByRegion();
   const currentLocation = getLocationAtPosition(playerPosition);
@@ -43,10 +39,8 @@ export function LocationList({
               location={location}
               playerPosition={playerPosition}
               playerFitness={playerFitness}
-              hasCarHere={hasCarHere}
               isCurrentLocation={currentLocation?.id === location.id}
-              onWalk={() => onWalk(location)}
-              onDrive={() => onDrive(location)}
+              onSelect={() => onSelect(location)}
             />
           )),
         ];

--- a/src/ui/components/map/TravelConfirmModal.css
+++ b/src/ui/components/map/TravelConfirmModal.css
@@ -1,0 +1,166 @@
+/* ==========================================================================
+   Travel Confirm Modal — Tier 1 Glass
+   ========================================================================== */
+
+.travel-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.travel-modal {
+  background: var(--glass-1-bg);
+  backdrop-filter: blur(var(--glass-1-blur));
+  -webkit-backdrop-filter: blur(var(--glass-1-blur));
+  border: var(--glass-1-border);
+  border-radius: var(--glass-1-radius);
+  box-shadow: var(--glass-1-shadow);
+  width: 380px;
+  padding: 32px;
+  display: flex;
+  flex-direction: column;
+  animation: modalIn 0.3s ease-out;
+}
+
+.travel-modal__title {
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--text-1);
+  text-shadow: var(--shadow-text);
+  text-align: center;
+  margin-bottom: 4px;
+}
+
+.travel-modal__subtitle {
+  font-size: 0.9rem;
+  color: var(--text-2);
+  text-shadow: var(--shadow-text);
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+.travel-modal__options {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+.travel-option {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  background: var(--glass-3-bg);
+  border: var(--glass-3-border);
+  border-radius: var(--glass-3-radius);
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.travel-option:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.travel-option--disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.travel-option--disabled:hover {
+  background: var(--glass-3-bg);
+}
+
+.travel-option__icon {
+  font-size: 1.3rem;
+  width: 28px;
+  text-align: center;
+  flex-shrink: 0;
+}
+
+.travel-option__info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.travel-option__label {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-1);
+  text-shadow: var(--shadow-text);
+}
+
+.travel-option__detail {
+  font-size: 0.8rem;
+  color: var(--text-3);
+  text-shadow: var(--shadow-text);
+}
+
+.travel-modal__cancel {
+  width: 100%;
+}
+
+/* ── Travel Loading Overlay ── */
+.travel-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.travel-loading {
+  background: var(--glass-1-bg);
+  backdrop-filter: blur(var(--glass-1-blur));
+  -webkit-backdrop-filter: blur(var(--glass-1-blur));
+  border: var(--glass-1-border);
+  border-radius: var(--glass-1-radius);
+  box-shadow: var(--glass-1-shadow);
+  width: 380px;
+  padding: 32px;
+  text-align: center;
+  animation: modalIn 0.3s ease-out;
+}
+
+.travel-loading__title {
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--text-1);
+  text-shadow: var(--shadow-text);
+  margin-bottom: 16px;
+}
+
+.travel-loading__bar-track {
+  width: 100%;
+  height: 6px;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 3px;
+  overflow: hidden;
+  margin-bottom: 12px;
+}
+
+.travel-loading__bar-fill {
+  height: 100%;
+  width: 0%;
+  background: var(--text-1);
+  border-radius: 3px;
+  animation: barFill 1.6s ease-in-out forwards;
+}
+
+.travel-loading__text {
+  font-size: 0.85rem;
+  color: var(--text-3);
+  animation: pulse 1s ease-in-out infinite;
+}

--- a/src/ui/components/map/TravelConfirmModal.tsx
+++ b/src/ui/components/map/TravelConfirmModal.tsx
@@ -1,0 +1,74 @@
+import {
+  type LocationDefinition,
+  type GridPosition,
+  calculateDistanceMeters,
+  calculateTravelTime,
+  getWalkingCost,
+} from '@engine/index';
+import './TravelConfirmModal.css';
+
+interface TravelConfirmModalProps {
+  location: LocationDefinition;
+  playerPosition: GridPosition;
+  playerFitness: number;
+  hasCarHere: boolean;
+  onWalk: () => void;
+  onDrive: () => void;
+  onCancel: () => void;
+}
+
+export function TravelConfirmModal({
+  location,
+  playerPosition,
+  playerFitness,
+  hasCarHere,
+  onWalk,
+  onDrive,
+  onCancel,
+}: TravelConfirmModalProps) {
+  const distanceMeters = calculateDistanceMeters(playerPosition, location.position);
+  const distanceKm = (distanceMeters / 1000).toFixed(1);
+  const walkTime = calculateTravelTime(playerPosition, location.position, 'walk');
+  const driveTime = calculateTravelTime(playerPosition, location.position, 'drive');
+  const walkCost = getWalkingCost(playerPosition, location.position, playerFitness);
+  const walkMinutes = Math.round(walkTime * 60);
+  const driveMinutes = Math.round(driveTime * 60);
+
+  return (
+    <div className="travel-backdrop" onClick={onCancel}>
+      <div className="travel-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="travel-modal__title">{location.name}</div>
+        <div className="travel-modal__subtitle">{distanceKm} km away</div>
+
+        <div className="travel-modal__options">
+          <div className="travel-option" onClick={onWalk}>
+            <span className="travel-option__icon">🚶</span>
+            <div className="travel-option__info">
+              <span className="travel-option__label">Walk</span>
+              <span className="travel-option__detail">
+                {walkMinutes} min · ⚡{walkCost.energyCost}
+              </span>
+            </div>
+          </div>
+
+          <div
+            className={`travel-option${!hasCarHere ? ' travel-option--disabled' : ''}`}
+            onClick={hasCarHere ? onDrive : undefined}
+          >
+            <span className="travel-option__icon">🚗</span>
+            <div className="travel-option__info">
+              <span className="travel-option__label">Drive</span>
+              <span className="travel-option__detail">
+                {hasCarHere ? `${driveMinutes} min` : 'No car here'}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <button className="travel-modal__cancel btn-secondary" onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/map/index.ts
+++ b/src/ui/components/map/index.ts
@@ -1,2 +1,3 @@
 export { LocationList } from './LocationList';
 export { LocationCard } from './LocationCard';
+export { TravelConfirmModal } from './TravelConfirmModal';

--- a/src/ui/screens/GameScreen.tsx
+++ b/src/ui/screens/GameScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useGameStore } from '@store/index';
 import { LocationList, TravelConfirmModal } from '@ui/components/map';
 import { ActivityCard, ActivityModal, CarCard, CarSelector, BrowseResultsModal } from '@ui/components/location';
@@ -121,16 +121,31 @@ export function GameScreen({
 
   // Watch for listings_shown events to open browse modal.
   // Delay opening until the activity modal's progress bar finishes (2800ms).
+  // Timer is stored in a ref so that the clearEvents() re-render doesn't cancel it.
+  const browseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (browseTimerRef.current) {
+        clearTimeout(browseTimerRef.current);
+        browseTimerRef.current = null;
+      }
+    };
+  }, []);
+
   useEffect(() => {
     const listingsEvent = pendingEvents.find((e) => e.type === 'listings_shown');
     if (listingsEvent?.data?.listings) {
       clearEvents();
       const listings = listingsEvent.data.listings as CarListing[];
-      const timer = setTimeout(() => {
+      if (browseTimerRef.current) {
+        clearTimeout(browseTimerRef.current);
+      }
+      browseTimerRef.current = setTimeout(() => {
+        browseTimerRef.current = null;
         setSelectedActivity(null);
         setBrowseListings(listings);
       }, 2800);
-      return () => clearTimeout(timer);
     }
   }, [pendingEvents, clearEvents, setSelectedActivity]);
 

--- a/src/ui/screens/GameScreen.tsx
+++ b/src/ui/screens/GameScreen.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useGameStore } from '@store/index';
-import { LocationList } from '@ui/components/map';
+import { LocationList, TravelConfirmModal } from '@ui/components/map';
 import { ActivityCard, ActivityModal, CarCard, CarSelector, BrowseResultsModal } from '@ui/components/location';
 import { PauseMenu, ToastContainer, NewspaperModal } from '@ui/components/common';
 import {
@@ -53,6 +53,8 @@ export function GameScreen({
   const [showPauseMenu, setShowPauseMenu] = useState(false);
   const [showNewspaper, setShowNewspaper] = useState(false);
   const [browseListings, setBrowseListings] = useState<CarListing[] | null>(null);
+  const [pendingTravel, setPendingTravel] = useState<LocationDefinition | null>(null);
+  const [travelLoading, setTravelLoading] = useState<string | null>(null);
 
   const newspaperPurchasedToday =
     gameState.newspaper.purchased &&
@@ -173,23 +175,40 @@ export function GameScreen({
     setShowNewspaper(false);
   }, []);
 
-  const handleWalk = useCallback((location: LocationDefinition) => {
-    const result = walkTo(location.position);
-    if (result.success) {
-      addToast(`Walked to ${location.name}`, 'info');
-    } else if (result.error) {
-      addToast(result.error, 'error');
-    }
-  }, [walkTo, addToast]);
+  const handleLocationSelect = useCallback((location: LocationDefinition) => {
+    setPendingTravel(location);
+  }, []);
 
-  const handleDrive = useCallback((location: LocationDefinition) => {
-    const result = driveTo(location.position);
+  const handleTravelConfirm = useCallback((mode: 'walk' | 'drive') => {
+    if (!pendingTravel) return;
+    const location = pendingTravel;
+    setPendingTravel(null);
+
+    const result = mode === 'walk'
+      ? walkTo(location.position)
+      : driveTo(location.position);
+
     if (result.success) {
-      addToast(`Drove to ${location.name}`, 'info');
+      setTravelLoading(
+        mode === 'walk'
+          ? `Walking to ${location.name}...`
+          : `Driving to ${location.name}...`
+      );
     } else if (result.error) {
       addToast(result.error, 'error');
     }
-  }, [driveTo, addToast]);
+  }, [pendingTravel, walkTo, driveTo, addToast]);
+
+  // Travel loading → transition back to location tab
+  useEffect(() => {
+    if (travelLoading) {
+      const timer = setTimeout(() => {
+        setTravelLoading(null);
+        setTab('location');
+      }, 2000);
+      return () => clearTimeout(timer);
+    }
+  }, [travelLoading, setTab]);
 
   const handleMenuClick = () => {
     setShowPauseMenu(true);
@@ -225,7 +244,7 @@ export function GameScreen({
   const energyPct = (gameState.player.energy / MAX_ENERGY) * 100;
 
   return (
-    <div className={`game-screen game-screen--${timeOfDay}${showPauseMenu || selectedActivity || showNewspaper || browseListings ? ' game-screen--modal-open' : ''}`}>
+    <div className={`game-screen game-screen--${timeOfDay}${showPauseMenu || selectedActivity || showNewspaper || browseListings || pendingTravel || travelLoading ? ' game-screen--modal-open' : ''}`}>
       {/* Background */}
       <div className="bg">
         <div
@@ -445,8 +464,8 @@ export function GameScreen({
                 playerPosition={gameState.player.position}
                 playerFitness={gameState.player.stats.fitness}
                 hasCarHere={hasCarHere}
-                onWalk={handleWalk}
-                onDrive={handleDrive}
+                onWalk={handleLocationSelect}
+                onDrive={handleLocationSelect}
               />
             )}
           </div>
@@ -481,6 +500,32 @@ export function GameScreen({
           currentDay={gameState.time.currentDay}
           onClose={() => setBrowseListings(null)}
         />
+      )}
+
+      {/* Travel confirmation */}
+      {pendingTravel && (
+        <TravelConfirmModal
+          location={pendingTravel}
+          playerPosition={gameState.player.position}
+          playerFitness={gameState.player.stats.fitness}
+          hasCarHere={hasCarHere}
+          onWalk={() => handleTravelConfirm('walk')}
+          onDrive={() => handleTravelConfirm('drive')}
+          onCancel={() => setPendingTravel(null)}
+        />
+      )}
+
+      {/* Travel loading transition */}
+      {travelLoading && (
+        <div className="travel-loading-overlay">
+          <div className="travel-loading">
+            <div className="travel-loading__title">{travelLoading}</div>
+            <div className="travel-loading__bar-track">
+              <div className="travel-loading__bar-fill" />
+            </div>
+            <div className="travel-loading__text">Traveling...</div>
+          </div>
+        </div>
       )}
 
       {/* Toast notifications */}

--- a/src/ui/screens/GameScreen.tsx
+++ b/src/ui/screens/GameScreen.tsx
@@ -478,9 +478,7 @@ export function GameScreen({
               <LocationList
                 playerPosition={gameState.player.position}
                 playerFitness={gameState.player.stats.fitness}
-                hasCarHere={hasCarHere}
-                onWalk={handleLocationSelect}
-                onDrive={handleLocationSelect}
+                onSelect={handleLocationSelect}
               />
             )}
           </div>

--- a/src/ui/screens/GameScreen.tsx
+++ b/src/ui/screens/GameScreen.tsx
@@ -118,13 +118,17 @@ export function GameScreen({
   };
 
   // Watch for listings_shown events to open browse modal.
-  // Close the activity modal first so the progress bar doesn't linger behind.
+  // Delay opening until the activity modal's progress bar finishes (2800ms).
   useEffect(() => {
     const listingsEvent = pendingEvents.find((e) => e.type === 'listings_shown');
     if (listingsEvent?.data?.listings) {
-      setSelectedActivity(null);
-      setBrowseListings(listingsEvent.data.listings as CarListing[]);
       clearEvents();
+      const listings = listingsEvent.data.listings as CarListing[];
+      const timer = setTimeout(() => {
+        setSelectedActivity(null);
+        setBrowseListings(listings);
+      }, 2800);
+      return () => clearTimeout(timer);
     }
   }, [pendingEvents, clearEvents, setSelectedActivity]);
 


### PR DESCRIPTION
## Summary
- Fix browse junkers loading order: delay listings until progress bar animation completes (2800ms)
- Persist junker listings within the same day — reuse existing scrapyard listings instead of regenerating
- Add travel confirmation dialog with Walk/Drive options and a loading transition before arriving
- Fix music queue: BGM no longer loops the same track — advances to the next period track on end
- Swap activity/travel jingles: activities no longer play a jingle (BGM continues), travel uses the activity jingle sound
- Buff nap energy recovery from 2 to 5 per hour (Issue #50)

## Files changed
- `data/activities/misc.json` — nap energy base 2 → 5
- `src/engine/core/activity.ts` — listing persistence logic
- `src/hooks/useAudio.ts` — music queue advancement, jingle swap
- `src/ui/screens/GameScreen.tsx` — browse delay, travel confirm/loading, remove direct travel handlers
- `src/ui/components/map/TravelConfirmModal.tsx` — new travel confirmation modal
- `src/ui/components/map/TravelConfirmModal.css` — modal + loading transition styles
- `src/ui/components/map/index.ts` — export new component