### PR TITLE
feat: sleep & energy system rework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,5 +46,8 @@ saves/
 *.tmp
 *.temp
 
+# Design proposals
+sleep-proposal.md
+
 # Assets (too large for git)
 src/assets/tilesets/

--- a/data/activities/misc.json
+++ b/data/activities/misc.json
@@ -3,40 +3,6 @@
   "locationName": "Anywhere",
   "activities": [
     {
-      "id": "sleep",
-      "name": "Sleep",
-      "description": "Rest in your shitbox to recover energy. Requires a car at your location.",
-      "category": "rest",
-      "time": {
-        "type": "variable",
-        "minHours": 1,
-        "maxHours": 12,
-        "unit": "hour"
-      },
-      "energy": {
-        "type": "recover",
-        "mode": "perHour",
-        "base": 4,
-        "housingModifier": true,
-        "statModifier": {
-          "stat": "fitness",
-          "effect": "increase",
-          "formula": "base * (1 + fitness * 0.02)"
-        }
-      },
-      "money": {
-        "type": "none"
-      },
-      "prerequisites": [
-        {
-          "type": "hasCarHere"
-        }
-      ],
-      "outcomes": [],
-      "statGain": [],
-      "risks": []
-    },
-    {
       "id": "buy_newspaper",
       "name": "Buy Newspaper",
       "description": "Pick up today's paper. Find out what's happening — and whether any gigs are worth chasing.",
@@ -56,35 +22,6 @@
       },
       "prerequisites": [],
       "outcomes": [{ "type": "generateNewspaper" }],
-      "statGain": [],
-      "risks": []
-    },
-    {
-      "id": "nap",
-      "name": "Nap",
-      "description": "Take a short rest anywhere. Less effective than sleeping in a car.",
-      "category": "rest",
-      "time": {
-        "type": "variable",
-        "minHours": 1,
-        "maxHours": 8,
-        "unit": "hour"
-      },
-      "energy": {
-        "type": "recover",
-        "mode": "perHour",
-        "base": 5,
-        "statModifier": {
-          "stat": "fitness",
-          "effect": "increase",
-          "formula": "base * (1 + fitness * 0.02)"
-        }
-      },
-      "money": {
-        "type": "none"
-      },
-      "prerequisites": [],
-      "outcomes": [],
       "statGain": [],
       "risks": []
     }

--- a/data/economy.json
+++ b/data/economy.json
@@ -18,7 +18,8 @@
   },
 
   "rest": {
-    "shitboxEnergyPerHour": 4,
+    "crashOutEnergyPerHour": 5,
+    "shitboxEnergyPerHour": 6,
     "basicApartmentEnergyPerHour": 8,
     "niceApartmentEnergyPerHour": 10,
     "ownedHomeEnergyPerHour": 10,

--- a/src/engine/core/activity.ts
+++ b/src/engine/core/activity.ts
@@ -9,7 +9,7 @@ import type { EconomyConfig } from '../data';
 import { getActivityDefinition, getEconomyConfig, getCarDefinition, getScrapPricePerKg, getAllCarDefinitions } from '../data';
 import { generateNewspaper } from '../systems/newspaper';
 import { RNG } from '../utils/rng';
-import { checkPrerequisites, checkEnergyAvailable, checkMoneyAvailable } from '../utils/validators';
+import { checkPrerequisites, checkMoneyAvailable } from '../utils/validators';
 import {
   calculateEnergyCost,
   calculateEnergyRecovery,
@@ -97,15 +97,7 @@ export function executeActivity(input: ExecuteActivityInput): ActivityResult {
     }
   }
 
-  // 5. Check affordability
-  const energyCheck = checkEnergyAvailable(state, energyCost);
-  if (!energyCheck.valid) {
-    return {
-      success: false,
-      error: energyCheck.reason,
-    };
-  }
-
+  // 5. Check affordability (money only — energy can go negative)
   const moneyCheck = checkMoneyAvailable(state, moneyCost);
   if (!moneyCheck.valid) {
     return {
@@ -531,12 +523,6 @@ export function canPerformActivity(
   const prereqResult = checkPrerequisites(state, activity.prerequisites, params);
   if (!prereqResult.valid) {
     return { canPerform: false, reason: prereqResult.reason };
-  }
-
-  // Check energy
-  const energyCost = calculateEnergyCost(state, activity, params);
-  if (state.player.energy < energyCost) {
-    return { canPerform: false, reason: `Requires ${energyCost} energy.` };
   }
 
   // Check money — mirror the variable-cost pre-computation from executeActivity

--- a/src/engine/core/activity.ts
+++ b/src/engine/core/activity.ts
@@ -490,12 +490,6 @@ function generateNarrative(
   const hourStr = pluralizeHours(hours);
 
   switch (activityId) {
-    case 'sleep':
-      return `You slept for ${hourStr} and recovered ${energyChange} energy.`;
-
-    case 'nap':
-      return `You napped for ${hourStr} and recovered ${energyChange} energy.`;
-
     case 'refuel':
       return delta.carUpdates?.[0]
         ? `Filled up your car. (${hourStr})`

--- a/src/engine/core/activity.ts
+++ b/src/engine/core/activity.ts
@@ -478,7 +478,6 @@ function generateNarrative(
   hours: number
 ): string {
   const moneyChange = delta.player?.money ?? 0;
-  const energyChange = delta.player?.energy ?? 0;
   const hourStr = pluralizeHours(hours);
 
   switch (activityId) {

--- a/src/engine/core/time.ts
+++ b/src/engine/core/time.ts
@@ -24,11 +24,12 @@ export function advanceTime(
   currentTime: GameTime,
   hours: number
 ): TimeAdvanceResult {
-  let { currentDay, currentHour } = currentTime;
-  const { currentMinute } = currentTime;
+  let { currentDay } = currentTime;
 
-  // Add hours
-  currentHour += hours;
+  // Work in total minutes for precision (rounds fractional minutes)
+  const totalMinutes = currentTime.currentHour * 60 + currentTime.currentMinute + Math.round(hours * 60);
+  let currentHour = Math.floor(totalMinutes / 60);
+  const currentMinute = totalMinutes % 60;
 
   // Handle day overflow
   let daysAdvanced = 0;
@@ -41,7 +42,7 @@ export function advanceTime(
   return {
     newTime: {
       currentDay,
-      currentHour: Math.floor(currentHour),
+      currentHour,
       currentMinute,
     },
     newDayStarted: daysAdvanced > 0,

--- a/src/engine/data/index.ts
+++ b/src/engine/data/index.ts
@@ -116,6 +116,7 @@ export interface EconomyConfig {
     defaultFuelEfficiency: number;
   };
   rest: {
+    crashOutEnergyPerHour: number;
     shitboxEnergyPerHour: number;
     basicApartmentEnergyPerHour: number;
     niceApartmentEnergyPerHour: number;

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -115,6 +115,18 @@ export {
 // Newspaper system
 export { generateNewspaper } from './systems/newspaper';
 
+// Sleep system
+export {
+  getSleepOptions,
+  getSleepContext,
+  getChillPresets,
+  advanceTimeWithDayProcessing,
+  type SleepOption,
+  type SleepContext,
+  type ChillPreset,
+  type TimeAdvanceOutcome,
+} from './systems/sleep';
+
 // Travel system
 export {
   getWalkingCost,

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -121,6 +121,7 @@ export {
   getSleepContext,
   getChillPresets,
   advanceTimeWithDayProcessing,
+  formatSleepDuration,
   type SleepOption,
   type SleepContext,
   type ChillPreset,

--- a/src/engine/systems/sleep.ts
+++ b/src/engine/systems/sleep.ts
@@ -67,7 +67,7 @@ export function getSleepOptions(state: GameState): SleepOption[] {
       id: 'home',
       label: 'Sleep at home',
       rate,
-      hours: Math.ceil(toRecover / rate),
+      hours: toRecover / rate,
     });
   }
 
@@ -78,7 +78,7 @@ export function getSleepOptions(state: GameState): SleepOption[] {
       id: 'car',
       label: 'Sleep in your car',
       rate,
-      hours: Math.ceil(toRecover / rate),
+      hours: toRecover / rate,
     });
   }
 
@@ -88,7 +88,7 @@ export function getSleepOptions(state: GameState): SleepOption[] {
     id: 'crash',
     label: 'Crash out',
     rate: crashRate,
-    hours: Math.ceil(toRecover / crashRate),
+    hours: toRecover / crashRate,
   });
 
   return options;
@@ -164,7 +164,7 @@ export function advanceTimeWithDayProcessing(
   const allEvents: GameEvent[] = [];
 
   while (remainingHours > 0) {
-    const hoursUntilMidnight = HOURS_PER_DAY - currentState.time.currentHour;
+    const hoursUntilMidnight = HOURS_PER_DAY - currentState.time.currentHour - currentState.time.currentMinute / 60;
 
     if (remainingHours >= hoursUntilMidnight && hoursUntilMidnight > 0) {
       // This chunk crosses midnight
@@ -257,4 +257,20 @@ function hoursUntil(currentHour: number, targetHour: number): number {
   let h = targetHour - currentHour;
   if (h <= 0) h += HOURS_PER_DAY;
   return h;
+}
+
+// ============================================================================
+// Duration Formatting
+// ============================================================================
+
+/**
+ * Format a fractional hour value as a human-readable duration string.
+ * e.g. 2.7 → "2 hrs 42 min", 3.0 → "3 hrs", 0.5 → "30 min"
+ */
+export function formatSleepDuration(hours: number): string {
+  const h = Math.floor(hours);
+  const m = Math.round((hours - h) * 60);
+  if (m === 0) return `${h} hr${h !== 1 ? 's' : ''}`;
+  if (h === 0) return `${m} min`;
+  return `${h} hr${h !== 1 ? 's' : ''} ${m} min`;
 }

--- a/src/engine/systems/sleep.ts
+++ b/src/engine/systems/sleep.ts
@@ -3,7 +3,7 @@
  * Determines sleep options and rates based on player location and housing.
  */
 
-import type { GameState, GameEvent, GameTime, CarListing } from '../types';
+import type { GameState, GameEvent, GameTime } from '../types';
 import type { EconomyConfig } from '../data';
 import { getEconomyConfig, getLocation } from '../data';
 import { advanceTime, processNewDay, checkDeathConditions } from '../core/time';

--- a/src/engine/systems/sleep.ts
+++ b/src/engine/systems/sleep.ts
@@ -234,15 +234,15 @@ export function getChillPresets(currentTime: GameTime): ChillPreset[] {
   presets.push({ label: '2 hours', hours: 2 });
   presets.push({ label: '4 hours', hours: 4 });
 
-  // Until morning (6 AM)
+  // Until morning (6 AM) — hidden if already at 6 AM (would wrap to 24h)
   const hoursUntilMorning = hoursUntil(currentHour, 6);
-  if (hoursUntilMorning > 0) {
+  if (hoursUntilMorning > 0 && hoursUntilMorning < HOURS_PER_DAY) {
     presets.push({ label: 'Until morning', hours: hoursUntilMorning });
   }
 
-  // Until evening (18:00)
+  // Until evening (18:00) — hidden if already at 18:00 (would wrap to 24h)
   const hoursUntilEvening = hoursUntil(currentHour, 18);
-  if (hoursUntilEvening > 0) {
+  if (hoursUntilEvening > 0 && hoursUntilEvening < HOURS_PER_DAY) {
     presets.push({ label: 'Until evening', hours: hoursUntilEvening });
   }
 

--- a/src/engine/systems/sleep.ts
+++ b/src/engine/systems/sleep.ts
@@ -1,0 +1,260 @@
+/**
+ * Sleep & energy recovery system.
+ * Determines sleep options and rates based on player location and housing.
+ */
+
+import type { GameState, GameEvent, GameTime, CarListing } from '../types';
+import type { EconomyConfig } from '../data';
+import { getEconomyConfig, getLocation } from '../data';
+import { advanceTime, processNewDay, checkDeathConditions } from '../core/time';
+import { MAX_ENERGY, HOURS_PER_DAY } from '../index';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface SleepOption {
+  id: 'home' | 'car' | 'crash';
+  label: string;
+  rate: number;
+  hours: number;
+}
+
+export interface SleepContext {
+  /** Best available rate at the current location */
+  bestRate: number;
+  /** Best option label */
+  bestLabel: string;
+  /** Projected sleep hours at the best rate */
+  bestHours: number;
+  /** All available options (for crash prompt) */
+  options: SleepOption[];
+}
+
+export interface TimeAdvanceOutcome {
+  newState: GameState;
+  events: GameEvent[];
+  isDead: boolean;
+  deathReason?: string;
+}
+
+// ============================================================================
+// Sleep Rate Calculation
+// ============================================================================
+
+/**
+ * Determine all sleep options available at the player's current location.
+ * Options are ordered best-to-worst. "Sleep in car" is hidden when
+ * "Sleep at home" is available.
+ */
+export function getSleepOptions(state: GameState): SleepOption[] {
+  const config = getEconomyConfig();
+  const energy = state.player.energy;
+  const toRecover = MAX_ENERGY - energy; // Can be > 100 if energy is negative
+  const options: SleepOption[] = [];
+
+  const isAtHome = getIsAtHome(state);
+  const hasCarHere = state.inventory.cars.some(
+    (c) =>
+      c.position.x === state.player.position.x &&
+      c.position.y === state.player.position.y
+  );
+
+  // Home option
+  if (isAtHome) {
+    const rate = getHomeRate(state.player.housing.type, config);
+    options.push({
+      id: 'home',
+      label: 'Sleep at home',
+      rate,
+      hours: Math.ceil(toRecover / rate),
+    });
+  }
+
+  // Car option — hidden when at home
+  if (hasCarHere && !isAtHome) {
+    const rate = config.rest.shitboxEnergyPerHour;
+    options.push({
+      id: 'car',
+      label: 'Sleep in your car',
+      rate,
+      hours: Math.ceil(toRecover / rate),
+    });
+  }
+
+  // Crash out — always available
+  const crashRate = config.rest.crashOutEnergyPerHour;
+  options.push({
+    id: 'crash',
+    label: 'Crash out',
+    rate: crashRate,
+    hours: Math.ceil(toRecover / crashRate),
+  });
+
+  return options;
+}
+
+/**
+ * Get the full sleep context for the player's current location.
+ * Used for both voluntary sleep confirmation and crash prompt.
+ */
+export function getSleepContext(state: GameState): SleepContext {
+  const options = getSleepOptions(state);
+  const best = options[0]; // First option is always the best rate
+
+  return {
+    bestRate: best.rate,
+    bestLabel: best.label,
+    bestHours: best.hours,
+    options,
+  };
+}
+
+/**
+ * Check if the player is at their home location (renting or owning tier).
+ */
+function getIsAtHome(state: GameState): boolean {
+  const { housing } = state.player;
+  if (housing.type === 'shitbox' || !housing.propertyId) return false;
+
+  // propertyId maps to a location ID — check if player is at that location
+  const homeLoc = getLocation(housing.propertyId);
+  if (!homeLoc) return false;
+
+  return (
+    state.player.position.x === homeLoc.position.x &&
+    state.player.position.y === homeLoc.position.y
+  );
+}
+
+/**
+ * Get the home sleep rate based on housing tier.
+ */
+function getHomeRate(
+  housingType: 'shitbox' | 'renting' | 'owning',
+  config: EconomyConfig
+): number {
+  switch (housingType) {
+    case 'renting':
+      return config.rest.basicApartmentEnergyPerHour;
+    case 'owning':
+      return config.rest.ownedHomeEnergyPerHour;
+    default:
+      return config.rest.shitboxEnergyPerHour;
+  }
+}
+
+// ============================================================================
+// Time Advance with Day Boundary Processing
+// ============================================================================
+
+/**
+ * Advance time by the given hours, processing day boundary effects
+ * (food deduction, starvation, newspaper reset) for each midnight crossed.
+ *
+ * Used by both sleep and chill.
+ */
+export function advanceTimeWithDayProcessing(
+  state: GameState,
+  totalHours: number
+): TimeAdvanceOutcome {
+  const economyConfig = getEconomyConfig();
+  let currentState = { ...state };
+  let remainingHours = totalHours;
+  const allEvents: GameEvent[] = [];
+
+  while (remainingHours > 0) {
+    const hoursUntilMidnight = HOURS_PER_DAY - currentState.time.currentHour;
+
+    if (remainingHours >= hoursUntilMidnight && hoursUntilMidnight > 0) {
+      // This chunk crosses midnight
+      const timeResult = advanceTime(currentState.time, hoursUntilMidnight);
+      currentState = { ...currentState, time: timeResult.newTime };
+      remainingHours -= hoursUntilMidnight;
+
+      // Process new day
+      const dayResult = processNewDay(currentState, economyConfig);
+      currentState = {
+        ...currentState,
+        player: {
+          ...currentState.player,
+          money: currentState.player.money + dayResult.moneyChange,
+          daysWithoutFood: dayResult.daysWithoutFood,
+        },
+        newspaper: {
+          currentDay: currentState.time.currentDay,
+          content: null,
+          purchased: false,
+        },
+        market: dayResult.expiredListingsRemoved
+          ? { ...currentState.market, currentListings: dayResult.currentListings }
+          : currentState.market,
+      };
+      allEvents.push(...dayResult.events);
+
+      // Check death conditions
+      const deathCheck = checkDeathConditions(currentState, economyConfig);
+      if (deathCheck.isDead) {
+        return {
+          newState: currentState,
+          events: allEvents,
+          isDead: true,
+          deathReason: deathCheck.deathReason,
+        };
+      }
+    } else {
+      // Remaining hours don't cross midnight
+      const timeResult = advanceTime(currentState.time, remainingHours);
+      currentState = { ...currentState, time: timeResult.newTime };
+      remainingHours = 0;
+    }
+  }
+
+  return { newState: currentState, events: allEvents, isDead: false };
+}
+
+// ============================================================================
+// Chill Hour Presets
+// ============================================================================
+
+export interface ChillPreset {
+  label: string;
+  hours: number;
+}
+
+/**
+ * Get available chill presets based on the current time.
+ * Filters out presets that would be 0 hours.
+ */
+export function getChillPresets(currentTime: GameTime): ChillPreset[] {
+  const { currentHour } = currentTime;
+  const presets: ChillPreset[] = [];
+
+  presets.push({ label: '1 hour', hours: 1 });
+  presets.push({ label: '2 hours', hours: 2 });
+  presets.push({ label: '4 hours', hours: 4 });
+
+  // Until morning (6 AM)
+  const hoursUntilMorning = hoursUntil(currentHour, 6);
+  if (hoursUntilMorning > 0) {
+    presets.push({ label: 'Until morning', hours: hoursUntilMorning });
+  }
+
+  // Until evening (18:00)
+  const hoursUntilEvening = hoursUntil(currentHour, 18);
+  if (hoursUntilEvening > 0) {
+    presets.push({ label: 'Until evening', hours: hoursUntilEvening });
+  }
+
+  return presets;
+}
+
+/**
+ * Hours from currentHour until targetHour (wrapping around midnight).
+ * Returns 0 only if we're exactly at the target.
+ */
+function hoursUntil(currentHour: number, targetHour: number): number {
+  let h = targetHour - currentHour;
+  if (h <= 0) h += HOURS_PER_DAY;
+  return h;
+}

--- a/src/engine/systems/travel.ts
+++ b/src/engine/systems/travel.ts
@@ -110,20 +110,10 @@ export function getDrivingCost(
  * Check if the player can walk to a destination.
  */
 export function canWalk(
-  state: GameState,
-  to: GridPosition
+  _state: GameState,
+  _to: GridPosition
 ): { canTravel: boolean; reason?: string } {
-  const from = state.player.position;
-  const fitnessLevel = state.player.stats.fitness;
-  const cost = getWalkingCost(from, to, fitnessLevel);
-
-  if (state.player.energy < cost.energyCost) {
-    return {
-      canTravel: false,
-      reason: `Not enough energy. Need ${cost.energyCost}, have ${state.player.energy}`,
-    };
-  }
-
+  // Walking is always allowed — energy can go negative, triggering crash prompt
   return { canTravel: true };
 }
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -227,10 +227,7 @@ function applyDelta(state: GameState, delta: StateDelta): GameState {
   if (delta.player) {
     newState.player = {
       ...state.player,
-      energy: Math.max(
-        0,
-        Math.min(MAX_ENERGY, state.player.energy + (delta.player.energy ?? 0))
-      ),
+      energy: Math.min(MAX_ENERGY, state.player.energy + (delta.player.energy ?? 0)),
       money: state.player.money + (delta.player.money ?? 0),
       daysWithoutFood:
         delta.player.daysWithoutFood !== undefined
@@ -520,10 +517,6 @@ export const useGameStore = create<GameStore>()(
         const fitnessReduction = gameState.player.stats.fitness * economyConfig.statEffects.fitness.energyCostReductionPerPoint;
         const energyCost = Math.max(0, Math.round(baseEnergy * (1 - fitnessReduction)));
 
-        if (gameState.player.energy < energyCost) {
-          return { success: false, error: `Not enough energy. Need ${energyCost}, have ${gameState.player.energy}.` };
-        }
-
         // Apply gig: deduct time, deduct energy, add pay, mark taken
         const timeResult = advanceTime(gameState.time, gig.timeCost);
         const updatedGigs = content.gigs.map((g: GigListing) =>
@@ -534,7 +527,7 @@ export const useGameStore = create<GameStore>()(
           ...gameState,
           player: {
             ...gameState.player,
-            energy: Math.max(0, gameState.player.energy - energyCost),
+            energy: gameState.player.energy - energyCost,
             money: gameState.player.money + gig.pay,
           },
           time: timeResult.newTime,
@@ -640,7 +633,7 @@ export const useGameStore = create<GameStore>()(
               ...newState,
               player: {
                 ...newState.player,
-                energy: Math.max(0, newState.player.energy + result.delta.player.energy),
+                energy: newState.player.energy + result.delta.player.energy,
               },
             };
           }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -736,7 +736,7 @@ export const useGameStore = create<GameStore>()(
 
         const currentEnergy = gameState.player.energy;
         const toRecover = MAX_ENERGY - currentEnergy;
-        const sleepHours = Math.ceil(toRecover / rate);
+        const sleepHours = toRecover / rate;
 
         // Set energy to 100 first, then advance time with day processing
         let newState: GameState = {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -22,6 +22,7 @@ import {
   executeDrive,
   getLocation,
   getCarDefinition,
+  advanceTimeWithDayProcessing,
   type ActivityParams,
   type ActivityDefinition,
   type GigListing,
@@ -54,6 +55,9 @@ interface GameStore {
   toasts: ToastMessage[];
   isExecutingActivity: boolean;
 
+  // Sleep/crash state
+  crashPromptActive: boolean;
+
   // Audio state
   muted: boolean;
   audioEvent: AudioEvent | null;
@@ -74,6 +78,10 @@ interface GameStore {
   // Travel
   walkTo: (destination: GridPosition) => { success: boolean; error?: string };
   driveTo: (destination: GridPosition) => { success: boolean; error?: string };
+
+  // Sleep & Chill
+  sleep: (rate: number) => void;
+  chill: (hours: number) => void;
 
   // Navigation
   setScreen: (screen: Screen) => void;
@@ -304,6 +312,7 @@ export const useGameStore = create<GameStore>()(
       pendingEvents: [],
       toasts: [],
       isExecutingActivity: false,
+      crashPromptActive: false,
       muted: false,
       audioEvent: null,
 
@@ -373,6 +382,7 @@ export const useGameStore = create<GameStore>()(
           pendingEvents: [],
           toasts: [],
           isExecutingActivity: false,
+          crashPromptActive: false,
         });
       },
 
@@ -476,9 +486,13 @@ export const useGameStore = create<GameStore>()(
           },
         };
 
+        // Check for crash (energy <= 0)
+        const crashed = newState.player.energy <= 0;
+
         set({
           gameState: newState,
           pendingEvents: allEvents,
+          crashPromptActive: crashed,
         });
 
         return result;
@@ -596,7 +610,10 @@ export const useGameStore = create<GameStore>()(
           }
         }
 
-        set({ gameState: newState, pendingEvents: allEvents });
+        // Check for crash (energy <= 0)
+        const crashed = newState.player.energy <= 0;
+
+        set({ gameState: newState, pendingEvents: allEvents, crashPromptActive: crashed });
         return { success: true };
       },
 
@@ -644,7 +661,10 @@ export const useGameStore = create<GameStore>()(
           }
         }
 
-        set({ gameState: newState, audioEvent: 'travel' });
+        // Check for crash (energy <= 0)
+        const crashed = newState.player.energy <= 0;
+
+        set({ gameState: newState, audioEvent: 'travel', crashPromptActive: crashed });
         return { success: true };
       },
 
@@ -707,6 +727,106 @@ export const useGameStore = create<GameStore>()(
 
         set({ gameState: newState, audioEvent: 'travel' });
         return { success: true };
+      },
+
+      // Sleep & Chill
+      sleep: (rate) => {
+        const { gameState } = get();
+        if (!gameState) return;
+
+        const currentEnergy = gameState.player.energy;
+        const toRecover = MAX_ENERGY - currentEnergy;
+        const sleepHours = Math.ceil(toRecover / rate);
+
+        // Set energy to 100 first, then advance time with day processing
+        let newState: GameState = {
+          ...gameState,
+          player: { ...gameState.player, energy: MAX_ENERGY },
+        };
+
+        const outcome = advanceTimeWithDayProcessing(newState, sleepHours);
+        newState = outcome.newState;
+
+        // Log action
+        newState = {
+          ...newState,
+          history: {
+            ...newState.history,
+            actions: [
+              ...newState.history.actions.slice(-99),
+              {
+                timestamp: Date.now(),
+                day: newState.time.currentDay,
+                action: 'sleep',
+                params: { rate, hours: sleepHours },
+                result: 'success' as const,
+              },
+            ],
+          },
+        };
+
+        if (outcome.isDead) {
+          set({
+            gameState: newState,
+            currentScreen: 'game_over',
+            crashPromptActive: false,
+            pendingEvents: [
+              ...outcome.events,
+              { type: 'death' as const, message: outcome.deathReason ?? 'You died.' },
+            ],
+          });
+          return;
+        }
+
+        set({
+          gameState: newState,
+          crashPromptActive: false,
+          pendingEvents: outcome.events,
+        });
+      },
+
+      chill: (hours) => {
+        const { gameState } = get();
+        if (!gameState) return;
+        if (gameState.player.energy <= 0) return; // Can't chill while crashed
+
+        const outcome = advanceTimeWithDayProcessing(gameState, hours);
+        let newState = outcome.newState;
+
+        // Log action
+        newState = {
+          ...newState,
+          history: {
+            ...newState.history,
+            actions: [
+              ...newState.history.actions.slice(-99),
+              {
+                timestamp: Date.now(),
+                day: newState.time.currentDay,
+                action: 'chill',
+                params: { hours },
+                result: 'success' as const,
+              },
+            ],
+          },
+        };
+
+        if (outcome.isDead) {
+          set({
+            gameState: newState,
+            currentScreen: 'game_over',
+            pendingEvents: [
+              ...outcome.events,
+              { type: 'death' as const, message: outcome.deathReason ?? 'You died.' },
+            ],
+          });
+          return;
+        }
+
+        set({
+          gameState: newState,
+          pendingEvents: outcome.events,
+        });
       },
 
       // Navigation

--- a/src/ui/components/location/ChillModal.css
+++ b/src/ui/components/location/ChillModal.css
@@ -1,0 +1,90 @@
+/* ==========================================================================
+   Chill Modal — Time Skip Presets
+   ========================================================================== */
+
+.chill-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.chill-modal {
+  background: var(--glass-1-bg);
+  backdrop-filter: blur(var(--glass-1-blur));
+  -webkit-backdrop-filter: blur(var(--glass-1-blur));
+  border: var(--glass-1-border);
+  border-radius: var(--glass-1-radius);
+  box-shadow: var(--glass-1-shadow);
+  width: 380px;
+  padding: 32px;
+  display: flex;
+  flex-direction: column;
+  animation: modalIn 0.3s ease-out;
+}
+
+.chill-modal__title {
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--text-1);
+  text-shadow: var(--shadow-text);
+  text-align: center;
+  margin-bottom: 4px;
+}
+
+.chill-modal__subtitle {
+  font-size: 0.9rem;
+  color: var(--text-2);
+  text-shadow: var(--shadow-text);
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+.chill-modal__presets {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 20px;
+}
+
+.chill-preset {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  background: var(--glass-3-bg);
+  border: var(--glass-3-border);
+  border-radius: var(--glass-3-radius);
+  cursor: pointer;
+  transition: background 0.15s;
+  text-align: left;
+  color: inherit;
+  font-family: inherit;
+  font-size: inherit;
+}
+
+.chill-preset:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.chill-preset__label {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-1);
+  text-shadow: var(--shadow-text);
+}
+
+.chill-preset__detail {
+  font-size: 0.8rem;
+  color: var(--text-3);
+  text-shadow: var(--shadow-text);
+}
+
+.chill-modal__cancel {
+  width: 100%;
+}

--- a/src/ui/components/location/ChillModal.tsx
+++ b/src/ui/components/location/ChillModal.tsx
@@ -1,0 +1,40 @@
+import type { ChillPreset } from '@engine/index';
+import './ChillModal.css';
+
+interface ChillModalProps {
+  presets: ChillPreset[];
+  onChill: (hours: number) => void;
+  onCancel: () => void;
+}
+
+export function ChillModal({ presets, onChill, onCancel }: ChillModalProps) {
+  return (
+    <div className="chill-backdrop" onClick={onCancel}>
+      <div className="chill-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="chill-modal__title">Chill</div>
+        <div className="chill-modal__subtitle">
+          Kick back and let time pass. No energy cost.
+        </div>
+
+        <div className="chill-modal__presets">
+          {presets.map((preset) => (
+            <button
+              key={preset.label}
+              className="chill-preset"
+              onClick={() => onChill(preset.hours)}
+            >
+              <span className="chill-preset__label">{preset.label}</span>
+              {preset.hours > 4 && (
+                <span className="chill-preset__detail">{preset.hours} hrs</span>
+              )}
+            </button>
+          ))}
+        </div>
+
+        <button className="btn-secondary chill-modal__cancel" onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/location/SleepModal.css
+++ b/src/ui/components/location/SleepModal.css
@@ -1,0 +1,150 @@
+/* ==========================================================================
+   Sleep Modal — Voluntary + Crash Prompt
+   ========================================================================== */
+
+.sleep-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.sleep-backdrop--crash {
+  background: rgba(0, 0, 0, 0.75);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+}
+
+.sleep-modal {
+  background: var(--glass-1-bg);
+  backdrop-filter: blur(var(--glass-1-blur));
+  -webkit-backdrop-filter: blur(var(--glass-1-blur));
+  border: var(--glass-1-border);
+  border-radius: var(--glass-1-radius);
+  box-shadow: var(--glass-1-shadow);
+  width: 380px;
+  padding: 32px;
+  display: flex;
+  flex-direction: column;
+  animation: modalIn 0.3s ease-out;
+}
+
+.sleep-modal__title {
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--text-1);
+  text-shadow: var(--shadow-text);
+  text-align: center;
+  margin-bottom: 4px;
+}
+
+.sleep-modal__title--crash {
+  color: var(--spend);
+}
+
+.sleep-modal__subtitle {
+  font-size: 0.9rem;
+  color: var(--text-2);
+  text-shadow: var(--shadow-text);
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+/* ── Voluntary sleep info rows ── */
+.sleep-modal__info {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 24px;
+}
+
+.sleep-modal__row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 14px;
+  background: var(--glass-3-bg);
+  border: var(--glass-3-border);
+  border-radius: var(--glass-3-radius);
+}
+
+.sleep-modal__row-label {
+  font-size: 0.9rem;
+  color: var(--text-2);
+  text-shadow: var(--shadow-text);
+}
+
+.sleep-modal__row-value {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-1);
+  text-shadow: var(--shadow-text);
+}
+
+.sleep-modal__buttons {
+  display: flex;
+  gap: 16px;
+}
+
+.sleep-modal__buttons > button {
+  flex: 1;
+}
+
+/* ── Crash prompt options ── */
+.sleep-modal__options {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.sleep-option {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  background: var(--glass-3-bg);
+  border: var(--glass-3-border);
+  border-radius: var(--glass-3-radius);
+  cursor: pointer;
+  transition: background 0.15s;
+  text-align: left;
+  color: inherit;
+  font-family: inherit;
+  font-size: inherit;
+}
+
+.sleep-option:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.sleep-option__icon {
+  font-size: 1.3rem;
+  width: 28px;
+  text-align: center;
+  flex-shrink: 0;
+}
+
+.sleep-option__info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.sleep-option__label {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-1);
+  text-shadow: var(--shadow-text);
+}
+
+.sleep-option__detail {
+  font-size: 0.8rem;
+  color: var(--text-3);
+  text-shadow: var(--shadow-text);
+}

--- a/src/ui/components/location/SleepModal.tsx
+++ b/src/ui/components/location/SleepModal.tsx
@@ -1,4 +1,5 @@
 import type { SleepOption } from '@engine/index';
+import { formatSleepDuration } from '@engine/index';
 import './SleepModal.css';
 
 interface SleepModalProps {
@@ -35,7 +36,7 @@ export function SleepModal({
             </div>
             <div className="sleep-modal__row">
               <span className="sleep-modal__row-label">Sleep duration</span>
-              <span className="sleep-modal__row-value">{bestHours} hr{bestHours !== 1 ? 's' : ''}</span>
+              <span className="sleep-modal__row-value">{formatSleepDuration(bestHours)}</span>
             </div>
             <div className="sleep-modal__row">
               <span className="sleep-modal__row-label">Wake up at</span>
@@ -72,7 +73,7 @@ export function SleepModal({
               <span className="sleep-option__info">
                 <span className="sleep-option__label">{opt.label}</span>
                 <span className="sleep-option__detail">
-                  {opt.rate} energy/hr &middot; {opt.hours} hr{opt.hours !== 1 ? 's' : ''}
+                  {opt.rate} energy/hr &middot; {formatSleepDuration(opt.hours)}
                 </span>
               </span>
             </button>

--- a/src/ui/components/location/SleepModal.tsx
+++ b/src/ui/components/location/SleepModal.tsx
@@ -1,0 +1,84 @@
+import type { SleepOption } from '@engine/index';
+import './SleepModal.css';
+
+interface SleepModalProps {
+  mode: 'voluntary' | 'crash';
+  /** Best rate/label/hours for voluntary; all options for crash */
+  options: SleepOption[];
+  bestLabel: string;
+  bestRate: number;
+  bestHours: number;
+  onSleep: (rate: number) => void;
+  onCancel?: () => void; // Only for voluntary
+}
+
+export function SleepModal({
+  mode,
+  options,
+  bestLabel,
+  bestRate,
+  bestHours,
+  onSleep,
+  onCancel,
+}: SleepModalProps) {
+  if (mode === 'voluntary') {
+    return (
+      <div className="sleep-backdrop">
+        <div className="sleep-modal" onClick={(e) => e.stopPropagation()}>
+          <div className="sleep-modal__title">Sleep</div>
+          <div className="sleep-modal__subtitle">{bestLabel}</div>
+
+          <div className="sleep-modal__info">
+            <div className="sleep-modal__row">
+              <span className="sleep-modal__row-label">Recovery rate</span>
+              <span className="sleep-modal__row-value">{bestRate} energy/hr</span>
+            </div>
+            <div className="sleep-modal__row">
+              <span className="sleep-modal__row-label">Sleep duration</span>
+              <span className="sleep-modal__row-value">{bestHours} hr{bestHours !== 1 ? 's' : ''}</span>
+            </div>
+            <div className="sleep-modal__row">
+              <span className="sleep-modal__row-label">Wake up at</span>
+              <span className="sleep-modal__row-value">100 energy</span>
+            </div>
+          </div>
+
+          <div className="sleep-modal__buttons">
+            <button className="btn-secondary" onClick={onCancel}>Cancel</button>
+            <button className="btn-primary" onClick={() => onSleep(bestRate)}>Sleep</button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Crash prompt — mandatory, no cancel
+  return (
+    <div className="sleep-backdrop sleep-backdrop--crash">
+      <div className="sleep-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="sleep-modal__title sleep-modal__title--crash">You're exhausted.</div>
+        <div className="sleep-modal__subtitle">You must rest before continuing.</div>
+
+        <div className="sleep-modal__options">
+          {options.map((opt) => (
+            <button
+              key={opt.id}
+              className="sleep-option"
+              onClick={() => onSleep(opt.rate)}
+            >
+              <span className="sleep-option__icon">
+                {opt.id === 'home' ? '🏠' : opt.id === 'car' ? '🚗' : '😴'}
+              </span>
+              <span className="sleep-option__info">
+                <span className="sleep-option__label">{opt.label}</span>
+                <span className="sleep-option__detail">
+                  {opt.rate} energy/hr &middot; {opt.hours} hr{opt.hours !== 1 ? 's' : ''}
+                </span>
+              </span>
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/location/index.ts
+++ b/src/ui/components/location/index.ts
@@ -3,3 +3,5 @@ export { ActivityModal } from './ActivityModal';
 export { CarCard } from './CarCard';
 export { CarSelector } from './CarSelector';
 export { BrowseResultsModal } from './BrowseResultsModal';
+export { SleepModal } from './SleepModal';
+export { ChillModal } from './ChillModal';

--- a/src/ui/screens/GameScreen.css
+++ b/src/ui/screens/GameScreen.css
@@ -178,6 +178,11 @@
   color: var(--text-2);
 }
 
+.energy-bar__text--danger {
+  color: var(--spend);
+  font-weight: 600;
+}
+
 .food-warn {
   font-size: 0.8rem;
   color: var(--energy-color);

--- a/src/ui/screens/GameScreen.tsx
+++ b/src/ui/screens/GameScreen.tsx
@@ -74,7 +74,7 @@ export function GameScreen({
     ? getLocationActivities(currentLocation.id)
     : [];
 
-  // Universal activities (nap, sleep) — loaded from misc.json
+  // Universal activities (buy_newspaper) — loaded from misc.json
   const universalActivities = getLocationActivities('misc');
 
   const hasCarHere = gameState.inventory.cars.some(

--- a/src/ui/screens/GameScreen.tsx
+++ b/src/ui/screens/GameScreen.tsx
@@ -11,6 +11,7 @@ import {
   getConditionRating,
   getSleepContext,
   getChillPresets,
+  formatSleepDuration,
   MAX_ENERGY,
   STAT_ORDER,
   getTimeOfDay,
@@ -275,9 +276,9 @@ export function GameScreen({
   const handleSleep = useCallback((rate: number) => {
     setShowSleepConfirm(false);
     const energy = gameState.player.energy;
-    const hrs = Math.ceil((MAX_ENERGY - energy) / rate);
+    const exactHours = (MAX_ENERGY - energy) / rate;
     setRestLoading({
-      label: `Sleeping for ${hrs} hour${hrs !== 1 ? 's' : ''}...`,
+      label: `Sleeping for ${formatSleepDuration(exactHours)}...`,
       action: () => sleep(rate),
     });
   }, [sleep, gameState.player.energy]);

--- a/src/ui/screens/GameScreen.tsx
+++ b/src/ui/screens/GameScreen.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useGameStore } from '@store/index';
 import { LocationList, TravelConfirmModal } from '@ui/components/map';
-import { ActivityCard, ActivityModal, CarCard, CarSelector, BrowseResultsModal } from '@ui/components/location';
+import { ActivityCard, ActivityModal, CarCard, CarSelector, BrowseResultsModal, SleepModal, ChillModal } from '@ui/components/location';
 import { PauseMenu, ToastContainer, NewspaperModal } from '@ui/components/common';
 import {
   getLocationActivities,
@@ -9,6 +9,8 @@ import {
   canPerformActivity,
   getCarDefinition,
   getConditionRating,
+  getSleepContext,
+  getChillPresets,
   MAX_ENERGY,
   STAT_ORDER,
   getTimeOfDay,
@@ -49,8 +51,13 @@ export function GameScreen({
   const setSelectedCarInstanceId = useGameStore((state) => state.setSelectedCarInstanceId);
   const pendingEvents = useGameStore((state) => state.pendingEvents);
   const clearEvents = useGameStore((state) => state.clearEvents);
+  const crashPromptActive = useGameStore((state) => state.crashPromptActive);
+  const sleep = useGameStore((state) => state.sleep);
+  const chill = useGameStore((state) => state.chill);
 
   const [showPauseMenu, setShowPauseMenu] = useState(false);
+  const [showSleepConfirm, setShowSleepConfirm] = useState(false);
+  const [showChillModal, setShowChillModal] = useState(false);
   const [showNewspaper, setShowNewspaper] = useState(false);
   const [browseListings, setBrowseListings] = useState<CarListing[] | null>(null);
   const [pendingTravel, setPendingTravel] = useState<LocationDefinition | null>(null);
@@ -247,6 +254,22 @@ export function GameScreen({
     setTab('map');
   };
 
+  // Sleep context — computed for both voluntary and crash UI
+  const sleepContext = getSleepContext(gameState);
+  const chillPresets = getChillPresets(gameState.time);
+  const canSleep = gameState.player.energy > 0;
+  const canChill = gameState.player.energy > 0;
+
+  const handleSleep = useCallback((rate: number) => {
+    setShowSleepConfirm(false);
+    sleep(rate);
+  }, [sleep]);
+
+  const handleChill = useCallback((hours: number) => {
+    setShowChillModal(false);
+    chill(hours);
+  }, [chill]);
+
   const timeOfDay = getTimeOfDay(gameState.time.currentHour);
 
   // Format clock
@@ -256,10 +279,10 @@ export function GameScreen({
   const displayHour = hour % 12 || 12;
   const clockStr = `${displayHour}:${String(minute).padStart(2, '0')} ${ampm}`;
 
-  const energyPct = (gameState.player.energy / MAX_ENERGY) * 100;
+  const energyPct = Math.max(0, (gameState.player.energy / MAX_ENERGY) * 100);
 
   return (
-    <div className={`game-screen game-screen--${timeOfDay}${showPauseMenu || selectedActivity || showNewspaper || browseListings || pendingTravel || travelLoading ? ' game-screen--modal-open' : ''}`}>
+    <div className={`game-screen game-screen--${timeOfDay}${showPauseMenu || selectedActivity || showNewspaper || browseListings || pendingTravel || travelLoading || showSleepConfirm || showChillModal || crashPromptActive ? ' game-screen--modal-open' : ''}`}>
       {/* Background */}
       <div className="bg">
         <div
@@ -307,7 +330,9 @@ export function GameScreen({
                 <div className="energy-bar__track">
                   <div className="energy-bar__fill" style={{ width: `${energyPct}%` }} />
                 </div>
-                <span className="energy-bar__text">{round1(gameState.player.energy)}</span>
+                <span className={`energy-bar__text${gameState.player.energy <= 0 ? ' energy-bar__text--danger' : ''}`}>
+                  {round1(gameState.player.energy)}
+                </span>
               </div>
               {gameState.player.daysWithoutFood > 0 && (
                 <div className="food-warn">🍔 !</div>
@@ -458,6 +483,36 @@ export function GameScreen({
                         </div>
                       )}
 
+                      {/* Sleep card — available when energy > 0 */}
+                      <div
+                        className={`card card--universal${!canSleep ? ' card--disabled' : ''}`}
+                        onClick={canSleep ? () => setShowSleepConfirm(true) : undefined}
+                        style={canSleep ? { cursor: 'pointer' } : undefined}
+                      >
+                        <div className="card__name">Sleep</div>
+                        <div className="card__desc">Rest and recover to full energy. Rate depends on your location.</div>
+                        <div className="card__divider" />
+                        <div className="card__cost">
+                          <span className="card__cost-icon card__cost-icon--energy">⚡</span>
+                          <span className="card__cost-text card__cost-text--earn">+{sleepContext.bestRate}/hr</span>
+                        </div>
+                      </div>
+
+                      {/* Chill card — available when energy > 0 */}
+                      <div
+                        className={`card card--universal${!canChill ? ' card--disabled' : ''}`}
+                        onClick={canChill ? () => setShowChillModal(true) : undefined}
+                        style={canChill ? { cursor: 'pointer' } : undefined}
+                      >
+                        <div className="card__name">Chill</div>
+                        <div className="card__desc">Kill time. No energy cost, no money cost.</div>
+                        <div className="card__divider" />
+                        <div className="card__cost">
+                          <span className="card__cost-icon card__cost-icon--time">⏱</span>
+                          <span className="card__cost-text card__cost-text--neutral">Skip time</span>
+                        </div>
+                      </div>
+
                       {/* Leave card — always present */}
                       <div className="card card--universal" onClick={handleLeave} style={{ cursor: 'pointer' }}>
                         <div className="card__name">Leave</div>
@@ -539,6 +594,40 @@ export function GameScreen({
             <div className="travel-loading__text">Traveling...</div>
           </div>
         </div>
+      )}
+
+      {/* Voluntary sleep confirmation */}
+      {showSleepConfirm && !crashPromptActive && (
+        <SleepModal
+          mode="voluntary"
+          options={sleepContext.options}
+          bestLabel={sleepContext.bestLabel}
+          bestRate={sleepContext.bestRate}
+          bestHours={sleepContext.bestHours}
+          onSleep={handleSleep}
+          onCancel={() => setShowSleepConfirm(false)}
+        />
+      )}
+
+      {/* Chill modal */}
+      {showChillModal && !crashPromptActive && (
+        <ChillModal
+          presets={chillPresets}
+          onChill={handleChill}
+          onCancel={() => setShowChillModal(false)}
+        />
+      )}
+
+      {/* Crash prompt — mandatory, blocks all actions */}
+      {crashPromptActive && (
+        <SleepModal
+          mode="crash"
+          options={sleepContext.options}
+          bestLabel={sleepContext.bestLabel}
+          bestRate={sleepContext.bestRate}
+          bestHours={sleepContext.bestHours}
+          onSleep={handleSleep}
+        />
       )}
 
       {/* Toast notifications */}

--- a/src/ui/screens/GameScreen.tsx
+++ b/src/ui/screens/GameScreen.tsx
@@ -62,6 +62,7 @@ export function GameScreen({
   const [browseListings, setBrowseListings] = useState<CarListing[] | null>(null);
   const [pendingTravel, setPendingTravel] = useState<LocationDefinition | null>(null);
   const [travelLoading, setTravelLoading] = useState<string | null>(null);
+  const [restLoading, setRestLoading] = useState<{ label: string; action: () => void } | null>(null);
 
   const newspaperPurchasedToday =
     gameState.newspaper.purchased &&
@@ -232,6 +233,17 @@ export function GameScreen({
     }
   }, [travelLoading, setTab]);
 
+  // Rest loading (sleep/chill/crash) → execute action after progress bar
+  useEffect(() => {
+    if (restLoading) {
+      const timer = setTimeout(() => {
+        restLoading.action();
+        setRestLoading(null);
+      }, 2000);
+      return () => clearTimeout(timer);
+    }
+  }, [restLoading]);
+
   const handleMenuClick = () => {
     setShowPauseMenu(true);
   };
@@ -262,12 +274,20 @@ export function GameScreen({
 
   const handleSleep = useCallback((rate: number) => {
     setShowSleepConfirm(false);
-    sleep(rate);
-  }, [sleep]);
+    const energy = gameState.player.energy;
+    const hrs = Math.ceil((MAX_ENERGY - energy) / rate);
+    setRestLoading({
+      label: `Sleeping for ${hrs} hour${hrs !== 1 ? 's' : ''}...`,
+      action: () => sleep(rate),
+    });
+  }, [sleep, gameState.player.energy]);
 
   const handleChill = useCallback((hours: number) => {
     setShowChillModal(false);
-    chill(hours);
+    setRestLoading({
+      label: `Chilling for ${hours} hour${hours !== 1 ? 's' : ''}...`,
+      action: () => chill(hours),
+    });
   }, [chill]);
 
   const timeOfDay = getTimeOfDay(gameState.time.currentHour);
@@ -282,7 +302,7 @@ export function GameScreen({
   const energyPct = Math.max(0, (gameState.player.energy / MAX_ENERGY) * 100);
 
   return (
-    <div className={`game-screen game-screen--${timeOfDay}${showPauseMenu || selectedActivity || showNewspaper || browseListings || pendingTravel || travelLoading || showSleepConfirm || showChillModal || crashPromptActive ? ' game-screen--modal-open' : ''}`}>
+    <div className={`game-screen game-screen--${timeOfDay}${showPauseMenu || selectedActivity || showNewspaper || browseListings || pendingTravel || travelLoading || restLoading || showSleepConfirm || showChillModal || crashPromptActive ? ' game-screen--modal-open' : ''}`}>
       {/* Background */}
       <div className="bg">
         <div
@@ -331,7 +351,7 @@ export function GameScreen({
                   <div className="energy-bar__fill" style={{ width: `${energyPct}%` }} />
                 </div>
                 <span className={`energy-bar__text${gameState.player.energy <= 0 ? ' energy-bar__text--danger' : ''}`}>
-                  {round1(gameState.player.energy)}
+                  {gameState.player.energy <= 0 ? '0' : round1(gameState.player.energy)}
                 </span>
               </div>
               {gameState.player.daysWithoutFood > 0 && (
@@ -596,6 +616,19 @@ export function GameScreen({
         </div>
       )}
 
+      {/* Rest loading (sleep/chill/crash progress bar) */}
+      {restLoading && (
+        <div className="travel-loading-overlay">
+          <div className="travel-loading">
+            <div className="travel-loading__title">{restLoading.label}</div>
+            <div className="travel-loading__bar-track">
+              <div className="travel-loading__bar-fill" />
+            </div>
+            <div className="travel-loading__text">Resting...</div>
+          </div>
+        </div>
+      )}
+
       {/* Voluntary sleep confirmation */}
       {showSleepConfirm && !crashPromptActive && (
         <SleepModal
@@ -618,8 +651,8 @@ export function GameScreen({
         />
       )}
 
-      {/* Crash prompt — mandatory, blocks all actions */}
-      {crashPromptActive && (
+      {/* Crash prompt — mandatory, blocks all actions. Delayed until other modals close. */}
+      {crashPromptActive && !selectedActivity && !travelLoading && !restLoading && (
         <SleepModal
           mode="crash"
           options={sleepContext.options}


### PR DESCRIPTION
## Summary
- **Remove old sleep/nap actions** from activity menus — replaced by new voluntary sleep + mandatory crash system
- **Allow negative energy** — activities and travel are never blocked by insufficient energy; energy can go below 0
- **Voluntary Sleep button** — available when energy > 0, shows confirmation with recovery rate and projected duration, always wakes at 100
- **Mandatory crash prompt** — fires when any action drops energy to 0 or below; action completes first, then blocks all further actions until the player chooses a rest option
- **Recovery rate ladder**: crash out 5/hr → car 6/hr → renting 8/hr → owning 10/hr. "Sleep in car" hidden when "Sleep at home" is available
- **Chill action** — available when energy > 0, zero-cost time skip with hour presets (1hr, 2hr, 4hr, Until morning, Until evening)
- **Day boundary effects** trigger during both sleep and chill when crossing midnight (food deduction, starvation, newspaper reset)
- **Update shitbox/car housing rate** from 4 to 6 energy/hr
- **Negative energy HUD display** — energy bar clamps to 0% width, text turns red

## What's NOT changed
- Energy cost formulas, fitness modifiers
- Time advancement system
- Starvation system
- Map travel (energy and time costs)
- Negotiation, car buying, or any Phase 4+ systems

## Test plan
- [ ] Start a new game — verify Sleep and Chill buttons appear in universal actions
- [ ] Click Sleep — verify confirmation modal shows rate, duration, confirm/cancel
- [ ] Confirm sleep — verify energy recharges to 100 and time advances
- [ ] Click Chill — verify preset options appear (1hr, 2hr, 4hr, Until morning, Until evening)
- [ ] Select a chill preset — verify time advances with no energy cost
- [ ] Do activities until energy drops below 0 — verify crash prompt fires after the action completes
- [ ] Crash prompt shows all available options with projected durations
- [ ] Cannot dismiss crash prompt — must choose a sleep option
- [ ] Sleep from crash prompt — verify energy recharges to 100
- [ ] Verify "Sleep in car" option hidden when at home with housing
- [ ] Verify day boundary effects fire when sleep/chill crosses midnight
- [ ] Verify negative energy displays correctly in HUD (red text, 0% bar)
- [ ] Walk with low energy — verify it succeeds (energy goes negative), then crash fires